### PR TITLE
fix: allowing regex underscore for container registry enforcement

### DIFF
--- a/pkg/webhook/pod/containerregistry_registry.go
+++ b/pkg/webhook/pod/containerregistry_registry.go
@@ -54,7 +54,7 @@ func (r registry) Tag() string {
 
 func NewRegistry(value string) Registry {
 	reg := make(registry)
-	r := regexp.MustCompile(`(((?P<registry>[a-zA-Z0-9-.]+)\/)?((?P<repository>[a-zA-Z0-9-.]+)\/))?(?P<image>[a-zA-Z0-9-.]+)(:(?P<tag>[a-zA-Z0-9-.]+))?`)
+	r := regexp.MustCompile(`(((?P<registry>[a-zA-Z0-9-._]+)\/)?((?P<repository>[a-zA-Z0-9-._]+)\/))?(?P<image>[a-zA-Z0-9-._]+)(:(?P<tag>[a-zA-Z0-9-._]+))?`)
 	match := r.FindStringSubmatch(value)
 	for i, name := range r.SubexpNames() {
 		if i > 0 && i <= len(match) {


### PR DESCRIPTION
Fixes [#460](https://github.com/clastix/capsule/issues/460)

Prevents a _ in container registry repository name breaking the regex used to split the image reference