### PR TITLE
feat: expose custom metrics for tenants status

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.14.0
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.18.1

--- a/pkg/stats/metrics.go
+++ b/pkg/stats/metrics.go
@@ -1,0 +1,44 @@
+package stats
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var activeTenantCount = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "capsule",
+		Subsystem: "tenants",
+		Name:      "status_active_count",
+		Help:      "Total number of active tenants",
+	},
+	[]string{},
+)
+
+var cordonedTenantCount = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "capsule",
+		Subsystem: "tenants",
+		Name:      "status_cordoned_count",
+		Help:      "Total number of cordoned tenants",
+	},
+	[]string{},
+)
+
+// controller-runtime uses metrics.Registry registry for exposed metrics. tenant_count will
+// be exposed with the rest of the controller-runtime metrics.
+func init() {
+	metrics.Registry.MustRegister(activeTenantCount, cordonedTenantCount)
+}
+
+// RecordActiveTenant increments capsule_tenants_status_active_count counter
+// metric
+func RecordActiveTenant() {
+	activeTenantCount.With(prometheus.Labels{}).Inc()
+}
+
+// RecordCordonedTenant increments capsule_tenants_status_cordoned_count counter
+// metric
+func RecordCordonedTenant() {
+	cordonedTenantCount.With(prometheus.Labels{}).Inc()
+}


### PR DESCRIPTION
closes #451

This commit adds pkg/stats that defines prometheus counters for  active and
cordoned tenants.

These metrics are exposed to controller-runtime. So they are visible on the
controller metrics endpoint.

This was tested manually , after creating a new tenant the metrics showed
up on the metrics service endpoint

```
# HELP capsule_tenants_status_active_count Total number of active tenants
# TYPE capsule_tenants_status_active_count counter
capsule_tenants_status_active_count 1
```

<!--
# General contribution criteria

Thanks for spending some time for improving and fixing Capsule!

We're still working on the outline of the contribution guidelines but we're
following ourselves these points:

- reference a previously opened issue: https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls#issues-and-pull-requests 
- including a sentence or two in the commit description for the
  changelog/release notes
- splitting changes into several and documented small commits
- limit the git subject to 50 characters and write as the continuation of the
  sentence "If applied, this commit will ..."
- explain what and why in the body, if more than a trivial change, wrapping at
  72 characters

If you have any issue or question, reach out us!
https://clastix.slack.com >>> #capsule channel 
-->
