### PR TITLE
feat: supporting OwnerReferencesPermissionEnforcement admission controller

### DIFF
--- a/controllers/rbac/owner_references_permission_enforcement.go
+++ b/controllers/rbac/owner_references_permission_enforcement.go
@@ -1,0 +1,115 @@
+// Copyright 2020-2021 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package rbac
+
+import (
+	"context"
+	"fmt"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	capsulev1beta2 "github.com/clastix/capsule/api/v1beta2"
+)
+
+type OwnerReferencesPermissionEnforcement struct {
+	Client client.Client
+}
+
+func (o OwnerReferencesPermissionEnforcement) resourceName(tnt *capsulev1beta2.Tenant) string {
+	return fmt.Sprintf("capsule:%s:orpe", tnt.Name)
+}
+
+func (o OwnerReferencesPermissionEnforcement) ensureClusterRole(ctx context.Context, tnt *capsulev1beta2.Tenant) (controllerutil.OperationResult, error) {
+	cr := rbacv1.ClusterRole{}
+	cr.Name = o.resourceName(tnt)
+
+	return controllerutil.CreateOrUpdate(ctx, o.Client, &cr, func() error {
+		cr.Rules = []rbacv1.PolicyRule{
+			{
+				Verbs:         []string{"update"},
+				APIGroups:     []string{capsulev1beta2.GroupVersion.Group},
+				Resources:     []string{"tenants/finalizers"},
+				ResourceNames: []string{tnt.Name},
+			},
+		}
+
+		return ctrl.SetControllerReference(tnt, &cr, o.Client.Scheme())
+	})
+}
+
+func (o OwnerReferencesPermissionEnforcement) ensureClusterRoleBinding(ctx context.Context, tnt *capsulev1beta2.Tenant) (controllerutil.OperationResult, error) {
+	crb := rbacv1.ClusterRoleBinding{}
+	crb.Name = o.resourceName(tnt)
+
+	return controllerutil.CreateOrUpdate(ctx, o.Client, &crb, func() error {
+		crb.Subjects = []rbacv1.Subject{}
+
+		for _, owner := range tnt.Spec.Owners {
+			crb.Subjects = append(crb.Subjects, rbacv1.Subject{
+				APIGroup: rbacv1.GroupName,
+				Kind:     owner.Kind.String(),
+				Name:     owner.Name,
+			})
+		}
+
+		crb.RoleRef = rbacv1.RoleRef{
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
+			Kind:     "ClusterRole",
+			Name:     o.resourceName(tnt),
+		}
+
+		return ctrl.SetControllerReference(tnt, &crb, o.Client.Scheme())
+	})
+}
+
+func (o OwnerReferencesPermissionEnforcement) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	logger := log.FromContext(ctx, "controller", "OwnerReferencesPermissionEnforcement")
+
+	tnt := capsulev1beta2.Tenant{}
+	if err := o.Client.Get(ctx, request.NamespacedName, &tnt); err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("object may have been deleted")
+
+			return reconcile.Result{}, nil
+		}
+
+		logger.Error(err, "cannot retrieve the desired Tenant")
+
+		return reconcile.Result{}, err
+	}
+	// ClusterRole
+	res, err := o.ensureClusterRole(ctx, &tnt)
+	if err != nil {
+		logger.Error(err, "cannot create OwnerReferencesPermissionEnforcement ClusterRole")
+
+		return reconcile.Result{}, err
+	}
+
+	logger.Info("ClusterRole reconciliation", "resource", "ClusterRole", "result", res)
+	// ClusterRoleBinding
+	res, err = o.ensureClusterRoleBinding(ctx, &tnt)
+	if err != nil {
+		logger.Error(err, "cannot create OwnerReferencesPermissionEnforcement ClusterRoleBinding")
+
+		return reconcile.Result{}, err
+	}
+
+	logger.Info("reconciliation completed", "resource", "ClusterRoleBinding", "result", res)
+
+	return reconcile.Result{}, nil
+}
+
+func (o OwnerReferencesPermissionEnforcement) SetupWithManager(mgr ctrl.Manager) (err error) {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&capsulev1beta2.Tenant{}).
+		Owns(&rbacv1.ClusterRoleBinding{}).
+		Owns(&rbacv1.ClusterRole{}).
+		Complete(o)
+}

--- a/main.go
+++ b/main.go
@@ -266,6 +266,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (rbaccontroller.OwnerReferencesPermissionEnforcement{Client: manager.GetClient()}).SetupWithManager(manager); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "OwnerReferencesPermissionEnforcement")
+		os.Exit(1)
+	}
+
 	if err = (&servicelabelscontroller.ServicesLabelsReconciler{
 		Log: ctrl.Log.WithName("controllers").WithName("ServiceLabels"),
 	}).SetupWithManager(ctx, manager); err != nil {


### PR DESCRIPTION
Closes #773.

Let's say I got this Tenant definition:

```yaml
apiVersion: capsule.clastix.io/v1beta2
kind: Tenant
metadata:
  name: test
spec:
  owners:
  - kind: User
    name: alice
```

As a result, the new controller will reconcile the following resources:

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: capsule:test:orpe
  ownerReferences:
  - apiVersion: capsule.clastix.io/v1beta2
    blockOwnerDeletion: true
    controller: true
    kind: Tenant
    name: test
    uid: 75722d36-f033-4727-8cd6-99b75b4e59dd
rules:
- apiGroups:
  - capsule.clastix.io
  resourceNames:
  - test
  resources:
  - tenants/finalizers
  verbs:
  - update
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: capsule:test:orpe
  ownerReferences:
  - apiVersion: capsule.clastix.io/v1beta2
    blockOwnerDeletion: true
    controller: true
    kind: Tenant
    name: test
    uid: 75722d36-f033-4727-8cd6-99b75b4e59dd
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: capsule:test:orpe
subjects:
- apiGroup: rbac.authorization.k8s.io
  kind: User
  name: alice
```

If the Tenant will be updated with different users, the resulting `ClusterRoleBinding` will reflect the owners.

As a result, `alice` will be allowed to patch Tenant finalizers.

```
$: kubectl --as alice --as-group capsule.clastix.io auth can-i update tenants/test --subresource finalizers
Warning: resource 'tenants' is not namespace scoped in group 'capsule.clastix.io'

yes
```