### PR TITLE
feat(helm): bump controller version and simplify release flow

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -15,11 +15,18 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: "Extract Version"
+        id: extract_version
+        run: |
+          GIT_TAG=${GITHUB_REF##*/}
+          VERSION=${GIT_TAG##*v}
+          echo "version=$(echo $VERSION)" >> $GITHUB_OUTPUT
       - name: Publish Helm chart
         uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 # v1.7.0
         with:
           token: "${{ secrets.HELM_CHARTS_PUSH_TOKEN }}"
           linting: off
+          chart_version: ${{ steps.extract_version.outputs.version }}
           charts_dir: charts
           charts_url: https://${{ github.repository_owner }}.github.io/charts
           owner: ${{ github.repository_owner }}
@@ -37,6 +44,12 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
+      - name: "Extract Version"
+        id: extract_version
+        run: |
+          GIT_TAG=${GITHUB_REF##*/}
+          VERSION=${GIT_TAG##*v}
+          echo "version=$(echo $VERSION)" >> $GITHUB_OUTPUT
       - name: Helm | Publish
         id: helm_publish
         uses: oliverbaehler/github-actions/helm-oci-chart@8dfd42735c85f6c58d5d4d6f3232cd0e39d1fe73 # v0.1.0
@@ -44,6 +57,7 @@ jobs:
           registry: ghcr.io
           repository: ${{ github.repository_owner }}/charts
           name: "capsule"
+          version: ${{ steps.extract_version.outputs.version }}
           registry-username: ${{ github.actor }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
           update-dependencies: 'true' # Defaults to false

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
   <a href="https://api.securityscorecards.dev/projects/github.com/projectcapsule/capsule/badge">
     <img src="https://api.securityscorecards.dev/projects/github.com/projectcapsule/capsule/badge"/>
   </a>
+  <a href="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/projectcapsule">
+    <img src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/projectcapsule"/>
+  </a>
 </p>
 
 <p align="center">

--- a/charts/capsule/Chart.yaml
+++ b/charts/capsule/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 description: A Helm chart to deploy the Capsule Operator for easily implementing,
   managing, and maintaining mutitenancy and access control in Kubernetes.
 home: https://github.com/projectcapsule/capsule
-icon: https://github.com/projectcapsule/capsule/raw/master/assets/logo/capsule_small.png
+icon: https://github.com/projectcapsule/capsule/raw/main/assets/logo/capsule_small.png
 keywords:
 - kubernetes
 - operator

--- a/charts/capsule/Chart.yaml
+++ b/charts/capsule/Chart.yaml
@@ -19,10 +19,9 @@ name: capsule
 sources:
 - https://github.com/projectcapsule/capsule
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
+# The version is overwritten by the release workflow.
 version: 0.4.6
 
 # This is the version number of the application being deployed.
 # This version number should be incremented each time you make changes to the application.
-appVersion: 0.3.3
+appVersion: 0.4.0-rc.1


### PR DESCRIPTION
<!--
# General contribution criteria

Thanks for spending some time for improving and fixing Capsule!

We're still working on the outline of the contribution guidelines but we're
following ourselves these points:

- reference a previously opened issue: https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls#issues-and-pull-requests 
- including a sentence or two in the commit description for the
  changelog/release notes
- splitting changes into several and documented small commits
- limit the git subject to 50 characters and write as the continuation of the
  sentence "If applied, this commit will ..."
- explain what and why in the body, if more than a trivial change, wrapping at
  72 characters

-->

This bumps the used controller image to 0.4.0-rc.1. In addition, when we release a helm chart (eg. helm-v1.0.0) the version is extracted from the tag (in the case 1.0.0) and then used to publish the chart. So the version in the Chart.yaml does no longer require bumping for new releases.
