### PR TITLE
docs(repo): add sbom reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ Please, refer to the maintainers file available [here](.github/maintainers.yaml)
 
 Please, refer to the [documentation page](https://capsule.clastix.io/docs/contributing/release).
 
+### Software Bill of Materials
+
+All OCI release artifacts include a Software Bill of Materials (SBOM) in CycloneDX JSON format. More information on this is available [here](SECURITY.md#software-bill-of-materials-sbom)
+
 # FAQ
 
 - Q. How to pronounce Capsule?


### PR DESCRIPTION
<!--
# General contribution criteria

Thanks for spending some time for improving and fixing Capsule!

We're still working on the outline of the contribution guidelines but we're
following ourselves these points:

- reference a previously opened issue: https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls#issues-and-pull-requests 
- including a sentence or two in the commit description for the
  changelog/release notes
- splitting changes into several and documented small commits
- limit the git subject to 50 characters and write as the continuation of the
  sentence "If applied, this commit will ..."
- explain what and why in the body, if more than a trivial change, wrapping at
  72 characters

-->

The CLO Monitor checks for an SBOM reference in the README.md, therefor adding it.
