### PR TITLE
chore(repo): remove scopes as mandatory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,4 +13,4 @@ updates:
       interval: daily
     rebase-strategy: disabled
     commit-message:
-      prefix: "ci"
+      prefix: "ci(deps)"

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -27,18 +27,7 @@ jobs:
             fix
             test
             sec
-          requireScope: false  
-          scopes: |
-            all
-            chart
-            operator
-            manifest
-            website
-            e2e
-            release
-            repo
-            deps
-            make
+          requireScope: false
           wip: false
           # If the PR only contains a single commit, the action will validate that
           # it matches the configured pattern.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,7 +173,7 @@ The semantics should indicate the change and it's impact. The general format for
     |    |_______ Scope
     |____________ Type
 
- The commits are checked on pull-request. If the commit message does not follow the format, the workflow will fail. See the [Types](#types) and [Scopes](#scopes) sections for more information.
+ The commits are checked on pull-request. If the commit message does not follow the format, the workflow will fail. See the [Types](#types) for the supported types. The scope is not required but helps to provide more context for your changes. Try to use a scope if possible.
 
 ### Types
 
@@ -187,17 +187,3 @@ The following types are allowed for commits and pull requests:
   * `test`: test related changes
   * `sec`: security related changes
 
-### Scopes
-
-The following types are allowed for commits and pull requests:
-
-  * `all`: changes that affect all components
-  * `chart`: changes to the Helm chart
-  * `operator`: changes to the operator
-  * `manifest`: changes to the manifest installer
-  * `website`: changes to the website
-  * `e2e`: changes to the e2e testing process
-  * `release`: changes to the release process
-  * `repo`: changes to general repository files
-  * `deps`: dependency updates
-  * `make`: changes to Makefile

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -15,6 +15,8 @@ project-lifecycle:
   - github:oliverbaehler
   - github:bsctl
   - github:MaxFedotov
+distribution-points:
+  - https://github.com/orgs/projectcapsule/packages?repo_name=capsule
 contribution-policy:
   accepts-pull-requests: true
   accepts-automated-pull-requests: true

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,8 +2,8 @@ const Configuration = {
     extends: ['@commitlint/config-conventional'],
     plugins: ['commitlint-plugin-function-rules'],
     rules: {
-      'scope-enum': [2, 'always', ['all', 'chart', 'operator', 'manifest', 'deps', 'release', 'website', 'repo', 'e2e', 'make']],
       'type-enum': [2, 'always', ['chore', 'ci', 'docs', 'feat', 'test', 'fix', 'sec']],
+      'body-max-line-length': [1, 'always', 500],
     },
     /*
      * Whether commitlint uses the default ignore rules, see the description above.


### PR DESCRIPTION
<!--
Read the contribution guidelines before creating a pull request.

https://github.com/projectcapsule/capsule/blob/main/CONTRIBUTING.md

Thanks for spending some time for improving and fixing Capsule!
-->

Mainly removes the requirement to create scoped, because its annoying.. :D