### PR TITLE
chore(security-insights): self-assessment evidence

### DIFF
--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -50,7 +50,9 @@ dependencies:
     sbom-url: https://github.com/projectcapsule/capsule/blob/main/SECURITY.md#software-bill-of-materials-sbom
 security-artifacts:
   self-assessment:
-    self-assessment-created: false
+    self-assessment-created: true
+    evidence-url:
+    - https://github.com/projectcapsule/capsule/blob/main/SELF_ASSESSMENT.md
 security-contacts:
 - type: email
   value: cncf-capsule-maintainers@lists.cncf.io


### PR DESCRIPTION
According to the [CLOMonitor documentation](https://clomonitor.io/docs/topics/checks/#self-assessment):

> The details of the security self-assessment (including the evidence url) are available in the security-artifacts > self-assessment section of the [OpenSSF Security Insights](https://github.com/ossf/security-insights-spec/blob/v1.0.0/specification.md) manifest file (SECURITY-INSIGHTS.yml) that should be located at the root of the repository.