### PR TITLE
feat(chart): allow custom role bindings

### DIFF
--- a/charts/capsule/README.md
+++ b/charts/capsule/README.md
@@ -114,6 +114,9 @@ Here the values you can override:
 | manager.options.logLevel | string | `"4"` | Set the log verbosity of the capsule with a value from 1 to 10 |
 | manager.options.nodeMetadata | object | `{"forbiddenAnnotations":{"denied":[],"deniedRegex":""},"forbiddenLabels":{"denied":[],"deniedRegex":""}}` | Allows to set the forbidden metadata for the worker nodes that could be patched by a Tenant |
 | manager.options.protectedNamespaceRegex | string | `""` | If specified, disallows creation of namespaces matching the passed regexp |
+| manager.rbac.create | bool | `true` | Specifies whether RBAC resources should be created. |
+| manager.rbac.existingClusterRoles | list | `[]` | Specifies further cluster roles to be added to the Capsule manager service account. |
+| manager.rbac.existingRoles | list | `[]` | Specifies further cluster roles to be added to the Capsule manager service account. |
 | manager.readinessProbe | object | `{"httpGet":{"path":"/readyz","port":10080}}` | Configure the readiness probe using Deployment probe spec |
 | manager.resources.limits.cpu | string | `"200m"` |  |
 | manager.resources.limits.memory | string | `"128Mi"` |  |

--- a/charts/capsule/ci/test-values.yaml
+++ b/charts/capsule/ci/test-values.yaml
@@ -1,5 +1,12 @@
 fullnameOverride: capsule
 manager:
+    # Manager RBAC
+  rbac:
+    create: true
+    existingClusterRoles:
+    - "view"
+    existingRoles:
+    - "some-role"
   resources:
     limits:
       cpu: 500m

--- a/charts/capsule/templates/rbac.yaml
+++ b/charts/capsule/templates/rbac.yaml
@@ -1,61 +1,4 @@
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ include "capsule.fullname" . }}-proxy-role
-  labels:
-    {{- include "capsule.labels" . | nindent 4 }}
-  {{- with .Values.customAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-rules:
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ include "capsule.fullname" . }}-metrics-reader
-  labels:
-    {{- include "capsule.labels" . | nindent 4 }}
-  {{- with .Values.customAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-rules:
-- nonResourceURLs:
-  - /metrics
-  verbs:
-  - get
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ include "capsule.fullname" . }}-proxy-rolebinding
-  labels:
-    {{- include "capsule.labels" . | nindent 4 }}
-  {{- with .Values.customAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ include "capsule.fullname" . }}-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: {{ include "capsule.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+{{- if $.Values.manager.rbac.create }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -75,3 +18,46 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "capsule.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- range $_, $cr := $.Values.manager.rbac.existingClusterRoles }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "capsule.fullname" $ }}-{{ $cr }}
+  labels:
+    {{- include "capsule.labels" $ | nindent 4 }}
+  {{- with $.Values.customAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $cr }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "capsule.serviceAccountName" $ }}
+  namespace: {{ $.Release.Namespace }}
+{{- end }}
+{{- range $_, $nr := $.Values.manager.rbac.existingRoles }}
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "capsule.fullname" $ }}-{{ $nr }}
+  labels:
+    {{- include "capsule.labels" $ | nindent 4 }}
+  {{- with $.Values.customAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $nr }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "capsule.serviceAccountName" $ }}
+  namespace: {{ $.Release.Namespace }}
+{{- end }}

--- a/charts/capsule/values.yaml
+++ b/charts/capsule/values.yaml
@@ -14,6 +14,17 @@ tls:
 # Manager Options
 manager:
 
+  # Manager RBAC
+  rbac:
+    # -- Specifies whether RBAC resources should be created.
+    create: true
+    # -- Specifies further cluster roles to be added to the Capsule manager service account.
+    existingClusterRoles: []
+    # - cluster-admin
+    # -- Specifies further cluster roles to be added to the Capsule manager service account.
+    existingRoles: []
+    # - namespace-admin
+
   # -- Set the controller deployment mode as `Deployment` or `DaemonSet`.
   kind: Deployment
 


### PR DESCRIPTION
<!--
Read the contribution guidelines before creating a pull request.

https://github.com/projectcapsule/capsule/blob/main/CONTRIBUTING.md

Thanks for spending some time for improving and fixing Capsule!
-->

I haven't found anything where we use these ClusterRoles. In addition allows users to reference their own clusterRoles or Roles (resolves #771)