### PR TITLE
fix(controller): respect group quotas for number of operating system threads allocated to goroutines

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.1 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	go.uber.org/automaxprocs v1.5.3 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/net v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/automaxprocs v1.5.3 h1:kWazyxZUrS3Gs4qUpbwo5kEIMGe/DAvi5Z4tl2NW4j8=
+go.uber.org/automaxprocs v1.5.3/go.mod h1:eRbA25aqJrxAbsLO0xy5jVwPt7FQnRgjW+efnwa1WM0=
 go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	goRuntime "runtime"
 
 	flag "github.com/spf13/pflag"
+	_ "go.uber.org/automaxprocs"
 	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"


### PR DESCRIPTION
<!--
Read the contribution guidelines before creating a pull request.

https://github.com/projectcapsule/capsule/blob/main/CONTRIBUTING.md

Thanks for spending some time for improving and fixing Capsule!
-->

If the GOMAXPROCS environment variable is not explicitly set when starting the Go process, it defaults to the output of the runtime.NumCPU() function, which represents the number of available CPU cores (i.e., the value of P). 

**Verify** 

To verify if that's true, i added the following to main.go:

```
func MaxParallelism() int {
	maxProcs := goRuntime.GOMAXPROCS(0)
	numCPU := goRuntime.NumCPU()
	if maxProcs < numCPU {
		return maxProcs
	}
	return numCPU
}

//nolint:maintidx
func main() {
	fmt.Println("MaxParallelism: ", MaxParallelism())
```

This print out how many cores will be allocated.

1. Deployed with the main build

```
kubectl logs -f capsule-controller-manager-8c89798fc-hv5gp -n capsule-system
MaxParallelism:  4
...
```

2. Deployed with the `go.uber.org/automaxprocs` import:

```
2023/11/30 09:52:53 maxprocs: Updating GOMAXPROCS=1: using minimum allowed GOMAXPROCS
MaxParallelism:  1
``` 

In both cases the controller had the following resources allocated:

```
manager:
  resources:
    limits:
      cpu: 500m
      memory: 512Mi
    requests:
      cpu: 200m
      memory: 128Mi
```

This only takes affect, if `resources.limits.cpu` are set. If no resources are set, the amount of host CPU cores are used:

```
2023/11/30 09:50:05 maxprocs: Leaving GOMAXPROCS=4: CPU quota undefined
MaxParallelism:  4
```

