### PR TITLE
feat(chart): add capsule-proxy 0.6.0 as optional dependency 

### DIFF
--- a/.github/configs/ct.yaml
+++ b/.github/configs/ct.yaml
@@ -2,6 +2,8 @@ remote: origin
 target-branch: main
 chart-dirs:
   - charts
+chart-repos:
+  - capsule=https://projectcapsule.github.io/charts/
 helm-extra-args: "--timeout 600s"  
 validate-chart-schema: false
 validate-maintainers: false

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,6 +57,6 @@ jobs:
           version: v0.14.0
       - uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
         with:
-          version: 3.3.4
+          version: v3.14.2
       - name: e2e testing
         run: make e2e/${{ matrix.k8s-version }}

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
+        with:
+          version: v3.14.2
       - name: Linting Chart
         run: helm lint ./charts/capsule
       - name: Setup Chart Linting

--- a/charts/capsule/Chart.lock
+++ b/charts/capsule/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: capsule-proxy
+  repository: oci://ghcr.io/projectcapsule/charts
+  version: 0.6.0
+digest: sha256:4cf05b352f1c38a821081cc01ac5f2a84ed7d68514a5b98e63edba5ab1c7b19e
+generated: "2024-03-05T17:09:58.383699+01:00"

--- a/charts/capsule/Chart.yaml
+++ b/charts/capsule/Chart.yaml
@@ -4,6 +4,12 @@ description: A Helm chart to deploy the Capsule Operator for easily implementing
   managing, and maintaining mutitenancy and access control in Kubernetes.
 home: https://github.com/projectcapsule/capsule
 icon: https://github.com/projectcapsule/capsule/raw/main/assets/logo/capsule_small.png
+dependencies:
+  - name: capsule-proxy
+    version: 0.6.0
+    repository: "oci://ghcr.io/projectcapsule/charts"
+    condition: proxy.enabled
+    alias: proxy
 keywords:
 - kubernetes
 - operator
@@ -18,10 +24,9 @@ maintainers:
 name: capsule
 sources:
 - https://github.com/projectcapsule/capsule
-# The version is overwritten by the release workflow.
+# Note: The version is overwritten by the release workflow.
 version: 0.6.0
-# This is the version number of the application being deployed.
-# This version number should be incremented each time you make changes to the application.
+# Note: The version is overwritten by the release workflow.
 appVersion: 0.5.0
 annotations:
   artifacthub.io/operator: "true"

--- a/charts/capsule/README.md
+++ b/charts/capsule/README.md
@@ -85,6 +85,7 @@ Here the values you can override:
 | podSecurityContext | object | `{"runAsGroup":1002,"runAsNonRoot":true,"runAsUser":1002,"seccompProfile":{"type":"RuntimeDefault"}}` | Set the securityContext for the Capsule pod |
 | podSecurityPolicy.enabled | bool | `false` | Specify if a Pod Security Policy must be created |
 | priorityClassName | string | `""` | Set the priority class name of the Capsule pod |
+| proxy.enabled | bool | `false` | Enable Installation of Capsule Proxy |
 | replicaCount | int | `1` | Set the replica count for capsule pod |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Set the securityContext for the Capsule container |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
@@ -118,10 +119,7 @@ Here the values you can override:
 | manager.rbac.existingClusterRoles | list | `[]` | Specifies further cluster roles to be added to the Capsule manager service account. |
 | manager.rbac.existingRoles | list | `[]` | Specifies further cluster roles to be added to the Capsule manager service account. |
 | manager.readinessProbe | object | `{"httpGet":{"path":"/readyz","port":10080}}` | Configure the readiness probe using Deployment probe spec |
-| manager.resources.limits.cpu | string | `"200m"` |  |
-| manager.resources.limits.memory | string | `"128Mi"` |  |
-| manager.resources.requests.cpu | string | `"200m"` |  |
-| manager.resources.requests.memory | string | `"128Mi"` |  |
+| manager.resources | object | `{}` | Set the resource requests/limits for the Capsule manager container |
 | manager.webhookPort | int | `9443` | Set an alternative to the default container port.  Useful for use in some kubernetes clusters (such as GKE Private) with aggregator routing turned on, because pod ports have to be opened manually on the firewall side |
 
 ### ServiceMonitor Parameters

--- a/charts/capsule/ci/proxy-values.yaml
+++ b/charts/capsule/ci/proxy-values.yaml
@@ -1,0 +1,7 @@
+proxy:
+  enabled: true
+manager:
+  resources:
+    requests:
+      cpu: 200m
+      memory: 128Mi

--- a/charts/capsule/ci/test-values.yaml
+++ b/charts/capsule/ci/test-values.yaml
@@ -1,16 +1,12 @@
 fullnameOverride: capsule
 manager:
-    # Manager RBAC
+  resources:
+    requests:
+      cpu: 200m
+      memory: 128Mi
   rbac:
     create: true
     existingClusterRoles:
     - "view"
     existingRoles:
     - "some-role"
-  resources:
-    limits:
-      cpu: 500m
-      memory: 512Mi
-    requests:
-      cpu: 200m
-      memory: 128Mi

--- a/charts/capsule/values.yaml
+++ b/charts/capsule/values.yaml
@@ -11,6 +11,11 @@ tls:
   # -- Override name of the Capsule TLS Secret name when externally managed.
   name: ""
 
+# Capsule Proxy
+proxy:
+  # -- Enable Installation of Capsule Proxy
+  enabled: false
+
 # Manager Options
 manager:
 
@@ -85,13 +90,8 @@ manager:
       path: /readyz
       port: 10080
 
-  resources:
-    limits:
-      cpu: 200m
-      memory: 128Mi
-    requests:
-      cpu: 200m
-      memory: 128Mi
+  # -- Set the resource requests/limits for the Capsule manager container
+  resources: {}
 
 # -- Configuration for `imagePullSecrets` so that you can use a private images registry.
 imagePullSecrets: []


### PR DESCRIPTION
<!--
Read the contribution guidelines before creating a pull request.

https://github.com/projectcapsule/capsule/blob/main/CONTRIBUTING.md

Thanks for spending some time for improving and fixing Capsule!
-->

Adds Capsule-Proxy as subchart. Another notable changes is, that resources are unset by default. This is the standard for any helm chart. All the other changes help to make the chart-testing work.
