### PR TITLE
chore: add luca kündig as maintainer

### DIFF
--- a/.github/maintainers.yaml
+++ b/.github/maintainers.yaml
@@ -27,3 +27,12 @@
   projects:
     - https://github.com/projectcapsule/capsule
     - https://github.com/projectcapsule/capsule-proxy
+- name: Luca Kündig
+  github: https://github.com/lucakuendig
+  company: Swisscom
+  projects:
+    - https://github.com/projectcapsule/capsule
+    - https://github.com/projectcapsule/capsule-proxy
+
+
+

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,12 +1,13 @@
 The current Maintainers Group for the [TODO: Projectname] Project consists of:
 
-| Name                      | Employer    | Responsibilities |
-| ------------------------- | ----------- | ---------------- |
-|  Adriano Pezzuto          | Clastix     |  Maintainer      |
-|  Dario Tranchitella       | Clastix     |  Maintainer      |
-|  Maksim Fedotov           | Wargaming   |  Maintainer      |
-|  Oliver Bähler            | Peak Scale  |  Maintainer      |
-|  Massimiliano Giovagnoli  | Proximus    |  Maintainer      |
+| Name                      | Employer    | Responsibilities           |
+| ------------------------- | ----------- | -------------------------- |
+|  Adriano Pezzuto          | Clastix     |  Maintainer                |
+|  Dario Tranchitella       | Clastix     |  Maintainer                |
+|  Maksim Fedotov           | Wargaming   |  Maintainer                |
+|  Oliver Bähler            | Peak Scale  |  Maintainer/Community      |
+|  Massimiliano Giovagnoli  | Proximus    |  Maintainer                |
+|  Luca Kündig              | Swisscom    |  Maintainer                |
 
 This list must be kept in sync with the [CNCF Project Maintainers list](https://github.com/cncf/foundation/blob/master/project-maintainers.csv).
 


### PR DESCRIPTION
<!--
Read the contribution guidelines before creating a pull request.

https://github.com/projectcapsule/capsule/blob/main/CONTRIBUTING.md

Thanks for spending some time for improving and fixing Capsule!
-->

Hello Maintainers.

This is my request to add my good friend @lucakuendig as an official maintainer for Capsule. We have worked together at Bedag and introduced Capsule to Bedag. Therefor he has strong knowledge we can profit from.

Another aspect of this action is to take pressure from @prometherion and @bsctl. They are currently focused on Kamaji and their business and I don't want to bother them to much with pull request. Building a larger community will require more maintainers. And I can assure, he's a fun pal!

Also note, he's currently employed by Swisscom, the largest Telecom provider in Switzerland.


