### PR TITLE
fix(controller): ensure iteration on capsule ownerreferences

### DIFF
--- a/e2e/namespace_additional_metadata_test.go
+++ b/e2e/namespace_additional_metadata_test.go
@@ -21,6 +21,14 @@ var _ = Describe("creating a Namespace for a Tenant with additional metadata", f
 	tnt := &capsulev1beta2.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "tenant-metadata",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "cap",
+					Kind:       "dummy",
+					Name:       "tenant-metadata",
+					UID:        "tenant-metadata",
+				},
+			},
 		},
 		Spec: capsulev1beta2.TenantSpec{
 			Owners: capsulev1beta2.OwnerListSpec{

--- a/pkg/webhook/namespace/freezed.go
+++ b/pkg/webhook/namespace/freezed.go
@@ -35,6 +35,10 @@ func (r *freezedHandler) OnCreate(client client.Client, decoder *admission.Decod
 		}
 
 		for _, objectRef := range ns.ObjectMeta.OwnerReferences {
+			if !isTenantOwnerReference(objectRef) {
+				continue
+			}
+
 			// retrieving the selected Tenant
 			tnt := &capsulev1beta2.Tenant{}
 			if err := client.Get(ctx, types.NamespacedName{Name: objectRef.Name}, tnt); err != nil {

--- a/pkg/webhook/namespace/prefix.go
+++ b/pkg/webhook/namespace/prefix.go
@@ -49,6 +49,10 @@ func (r *prefixHandler) OnCreate(clt client.Client, decoder *admission.Decoder, 
 			tnt := &capsulev1beta2.Tenant{}
 
 			for _, or := range ns.ObjectMeta.OwnerReferences {
+				if !isTenantOwnerReference(or) {
+					continue
+				}
+
 				// retrieving the selected Tenant
 				if err := clt.Get(ctx, types.NamespacedName{Name: or.Name}, tnt); err != nil {
 					return utils.ErroredResponse(err)

--- a/pkg/webhook/namespace/quota.go
+++ b/pkg/webhook/namespace/quota.go
@@ -31,6 +31,10 @@ func (r *quotaHandler) OnCreate(client client.Client, decoder *admission.Decoder
 		}
 
 		for _, objectRef := range ns.ObjectMeta.OwnerReferences {
+			if !isTenantOwnerReference(objectRef) {
+				continue
+			}
+
 			// retrieving the selected Tenant
 			tnt := &capsulev1beta2.Tenant{}
 			if err := client.Get(ctx, types.NamespacedName{Name: objectRef.Name}, tnt); err != nil {

--- a/pkg/webhook/namespace/user_metadata.go
+++ b/pkg/webhook/namespace/user_metadata.go
@@ -33,7 +33,12 @@ func (r *userMetadataHandler) OnCreate(client client.Client, decoder *admission.
 		}
 
 		tnt := &capsulev1beta2.Tenant{}
+
 		for _, objectRef := range ns.ObjectMeta.OwnerReferences {
+			if !isTenantOwnerReference(objectRef) {
+				continue
+			}
+
 			// retrieving the selected Tenant
 			if err := client.Get(ctx, types.NamespacedName{Name: objectRef.Name}, tnt); err != nil {
 				return utils.ErroredResponse(err)
@@ -83,7 +88,12 @@ func (r *userMetadataHandler) OnUpdate(client client.Client, decoder *admission.
 		}
 
 		tnt := &capsulev1beta2.Tenant{}
+
 		for _, objectRef := range newNs.ObjectMeta.OwnerReferences {
+			if !isTenantOwnerReference(objectRef) {
+				continue
+			}
+
 			// retrieving the selected Tenant
 			if err := client.Get(ctx, types.NamespacedName{Name: objectRef.Name}, tnt); err != nil {
 				return utils.ErroredResponse(err)

--- a/pkg/webhook/namespace/utils.go
+++ b/pkg/webhook/namespace/utils.go
@@ -1,0 +1,27 @@
+// Copyright 2020-2023 Project Capsule Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package namespace
+
+import (
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	capsulev1beta2 "github.com/projectcapsule/capsule/api/v1beta2"
+)
+
+const (
+	ObjectReferenceTenantKind = "Tenant"
+)
+
+func isTenantOwnerReference(or metav1.OwnerReference) bool {
+	parts := strings.Split(or.APIVersion, "/")
+	if len(parts) != 2 {
+		return false
+	}
+
+	group := parts[0]
+
+	return group == capsulev1beta2.GroupVersion.Group && or.Kind == ObjectReferenceTenantKind
+}


### PR DESCRIPTION
<!--
Read the contribution guidelines before creating a pull request.

https://github.com/projectcapsule/capsule/blob/main/CONTRIBUTING.md

Thanks for spending some time for improving and fixing Capsule!
-->

While automating capsule for a HCI solution i noticed we have this bug. If you try to add another ownerreference you are always met with this error:

```
error: namespaces "cluster-fx9kggjwjd" could not be patched: admission webhook "namespaces.capsule.clastix.io" denied the request: Tenant.capsule.clastix.io "fx9kggjwjd" not found
```

`fx9kggjwjd` is representative for the new ownerreference name added. This fix checks if the ownerreference is actually from a tenant, if not it's skipped.

