### PR TITLE
feat(metrics): provide metrics for tenant quotas

### DIFF
--- a/controllers/tenant/resourcequotas.go
+++ b/controllers/tenant/resourcequotas.go
@@ -23,6 +23,7 @@ import (
 
 	capsulev1beta2 "github.com/projectcapsule/capsule/api/v1beta2"
 	"github.com/projectcapsule/capsule/pkg/api"
+	"github.com/projectcapsule/capsule/pkg/metrics"
 	"github.com/projectcapsule/capsule/pkg/utils"
 )
 
@@ -51,6 +52,18 @@ func (r *Manager) syncResourceQuotas(ctx context.Context, tenant *capsulev1beta2
 	if typeLabel, err = utils.GetTypeLabel(&corev1.ResourceQuota{}); err != nil {
 		return err
 	}
+
+	// Remove prior metrics, to avoid cleaning up for metrics of deleted ResourceQuotas
+	metrics.TenantResourceUsage.DeletePartialMatch(map[string]string{"tenant": tenant.Name})
+	metrics.TenantResourceLimit.DeletePartialMatch(map[string]string{"tenant": tenant.Name})
+
+	// Expose the namespace quota and usage as metrics for the tenant
+	metrics.TenantResourceUsage.WithLabelValues(tenant.Name, "namespaces", "").Set(float64(tenant.Status.Size))
+
+	if tenant.Spec.NamespaceOptions != nil && tenant.Spec.NamespaceOptions.Quota != nil {
+		metrics.TenantResourceLimit.WithLabelValues(tenant.Name, "namespaces", "").Set(float64(*tenant.Spec.NamespaceOptions.Quota))
+	}
+
 	//nolint:nestif
 	if tenant.Spec.ResourceQuota.Scope == api.ResourceQuotaScopeTenant {
 		group := new(errgroup.Group)
@@ -101,6 +114,19 @@ func (r *Manager) syncResourceQuotas(ctx context.Context, tenant *capsulev1beta2
 					}
 
 					r.Log.Info("Computed " + name.String() + " quota for the whole Tenant is " + quantity.String())
+
+					// Expose usage and limit metrics for the resource (name) of the ResourceQuota (index)
+					metrics.TenantResourceUsage.WithLabelValues(
+						tenant.Name,
+						name.String(),
+						strconv.Itoa(index),
+					).Set(float64(quantity.MilliValue()) / 1000)
+
+					metrics.TenantResourceLimit.WithLabelValues(
+						tenant.Name,
+						name.String(),
+						strconv.Itoa(index),
+					).Set(float64(hardQuota.MilliValue()) / 1000)
 
 					switch quantity.Cmp(resourceQuota.Hard[name]) {
 					case 0:

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,30 @@
+// Copyright 2020-2023 Project Capsule Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	metricsPrefix = "capsule_"
+
+	TenantResourceUsage = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: metricsPrefix + "tenant_resource_usage",
+		Help: "Current resource usage for a given resource in a tenant",
+	}, []string{"tenant", "resource", "resourcequotaindex"})
+
+	TenantResourceLimit = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: metricsPrefix + "tenant_resource_limit",
+		Help: "Current resource limit for a given resource in a tenant",
+	}, []string{"tenant", "resource", "resourcequotaindex"})
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		TenantResourceUsage,
+		TenantResourceLimit,
+	)
+}


### PR DESCRIPTION
### Description
This PR adds two custom metrics for capsule tenants: 
- `capsule_tenant_resource_limit{resource="<resource>",resourcequotaindex="<index>",tenant="<tenant>"}`
- `capsule_tenant_resource_usage{resource="<resource>",resourcequotaindex="<index>",tenant="<tenant>"}`

### Usecase
When resourcequotas are configured via capsule at the Tenant scope, capacity planning is difficult via Prometheus metrics from i.e. kube-state-metrics, since the sum of the resourcequotas is not actually what's being enforced. Instead we can provide metrics that expose the aggregated resource limits and usage for a tenant.

### Example metrics

<details>

<summary>Tenant Resource</summary>

```yaml
apiVersion: capsule.clastix.io/v1beta2
kind: Tenant
metadata:
  name: test
spec:
  owners:
  - name: alice
    kind: User
  namespaceOptions:
    quota: 10
  resourceQuotas:
    scope: Tenant
    items:
    - hard:
        pods: 100
    - hard:
        limits.memory: 4Gi
        requests.memory: 4Gi
    - hard:
        requests.memory: 6Gi
```
</details>

<details>

<summary>Metrics</summary>

```yaml
# HELP capsule_tenant_resource_limit Current resource limit for a given resource in a tenant
# TYPE capsule_tenant_resource_limit gauge
capsule_tenant_resource_limit{resource="limits.memory",resourcequotaindex="1",tenant="test"} 4.294967296e+09
capsule_tenant_resource_limit{resource="namespaces",resourcequotaindex="",tenant="test"} 10
capsule_tenant_resource_limit{resource="pods",resourcequotaindex="0",tenant="test"} 100
capsule_tenant_resource_limit{resource="requests.memory",resourcequotaindex="1",tenant="test"} 4.294967296e+09
capsule_tenant_resource_limit{resource="requests.memory",resourcequotaindex="2",tenant="test"} 6.442450944e+09
# HELP capsule_tenant_resource_usage Current resource usage for a given resource in a tenant
# TYPE capsule_tenant_resource_usage gauge
capsule_tenant_resource_usage{resource="limits.memory",resourcequotaindex="1",tenant="test"} 2.68435456e+09
capsule_tenant_resource_usage{resource="namespaces",resourcequotaindex="",tenant="test"} 4
capsule_tenant_resource_usage{resource="pods",resourcequotaindex="0",tenant="test"} 20
capsule_tenant_resource_usage{resource="requests.memory",resourcequotaindex="1",tenant="test"} 2.68435456e+09
capsule_tenant_resource_usage{resource="requests.memory",resourcequotaindex="2",tenant="test"} 2.68435456e+09
```
</details>
