### PR TITLE
docs(guides): document fluxcd addon

### DIFF
--- a/docs/content/dictionary.txt
+++ b/docs/content/dictionary.txt
@@ -218,3 +218,7 @@ v2
 webhook
 webhooks
 wontfix
+Quickstart
+FluxCD
+addon
+kustomize-controller


### PR DESCRIPTION
This PR adds a quickstart section to use the integration with Flux, with the help of the [addon](https://github.com/projectcapsule/capsule-addon-fluxcd/).

The goal is to easy the understanding and the usage of the integration, for both the platform administrator and the Tenant owner user personas.

Still, I left the previous documentation and manual setup guide to a deep dive section.