### PR TITLE
chore: upgrade go toolchain to v1.22.5

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -21,6 +21,10 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version-file: 'go.mod'
       - name: Setup caches
         uses: ./.github/actions/setup-caches
         timeout-minutes: 5

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/projectcapsule/capsule
 
-go 1.22.0
-
-toolchain go1.22.2
+go 1.22.5
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
Closes #1122.

@oliverbaehler I guess this should be enough to force the usage of Go v1.22.5 upon the release process. There's the option gobinary for the GoRelease build options but defining the binary location according to the version could be cumbersome and too much different from CI to local dev-env (e.g.: I'm using `gvm`).