### PR TITLE
chore(ci): fixing code scanning

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,6 +1,10 @@
 name: CI gosec
 permissions:
+  # required for all workflows
+  security-events: write
+  # only required for workflows in private repositories
   actions: read
+  contents: read
 on:
   push:
     branches: [ "*" ]


### PR DESCRIPTION
Trying to solve the broken CI for the **CI gosec** workflow.

Reading the docs it seems we have to add the following options: https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#example-workflow-for-sarif-files-generated-outside-of-a-repository