### PR TITLE
chore(renovate): ignore docs folder

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,9 @@
   "commitMessageLowerCase": "auto",
   "semanticCommits": "enabled",
   "semanticCommitType": "feat",
+  "ignorePaths": [
+      "docs"
+  ],
   "flux": {
     "fileMatch": ["^.*flux\\.yaml$"]
   },


### PR DESCRIPTION
Since the `docs` folder contains data that must be migrated to the official documentation website, it's useless to receive notifications for outdated deps.