### PR TITLE
feat: Allow additional SANS for web certificate

### DIFF
--- a/charts/capsule/README.md
+++ b/charts/capsule/README.md
@@ -98,6 +98,7 @@ Here the values you can override:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Set affinity rules for the Capsule pod |
+| certManager.additionalSANS | list | `[]` | Specify additional SANS to add to the certificate |
 | certManager.generateCertificates | bool | `false` | Specifies whether capsule webhooks certificates should be generated using cert-manager |
 | customAnnotations | object | `{}` | Additional annotations which will be added to all resources created by Capsule helm chart |
 | customLabels | object | `{}` | Additional labels which will be added to all resources created by Capsule helm chart |

--- a/charts/capsule/templates/certificate.yaml
+++ b/charts/capsule/templates/certificate.yaml
@@ -27,6 +27,9 @@ spec:
   dnsNames:
   - {{ include "capsule.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc
   - {{ include "capsule.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+  {{- range  .Values.certManager.additionalSANS }}
+  - {{ toYaml . }} 
+  {{- end }}
   issuerRef:
     kind: Issuer
     name: {{ include "capsule.fullname" . }}-webhook-selfsigned

--- a/charts/capsule/values.yaml
+++ b/charts/capsule/values.yaml
@@ -212,7 +212,8 @@ serviceAccount:
 certManager:
   # -- Specifies whether capsule webhooks certificates should be generated using cert-manager
   generateCertificates: false
-
+  # -- Specify additional SANS to add to the certificate
+  additionalSANS: []
 # -- Additional labels which will be added to all resources created by Capsule helm chart
 customLabels: {}
 


### PR DESCRIPTION
This makes it possible to include extra variants of the service-name that aren't captured by the {{ include "capsule.fullname" }} macro

<!--
Read the contribution guidelines before creating a pull request.

https://github.com/projectcapsule/capsule/blob/main/CONTRIBUTING.md

Thanks for spending some time for improving and fixing Capsule!
-->
