### PR TITLE
docs(example): set matching proxy setting

### DIFF
--- a/docs/content/general/proxy.md
+++ b/docs/content/general/proxy.md
@@ -411,7 +411,7 @@ spec:
   - kind: User
     name: alice
     proxySettings:
-    - kind: PriorityClasses
+    - kind: RuntimeClasses
       operations:
       - List
   runtimeClasses:


### PR DESCRIPTION
Hello everyone

While consulting the documentation, I came across this [example](https://capsule.clastix.io/docs/general/proxy/#runtime-classes) of a `runtimeClass` configuration.

Even though the current `proxySettings` type is [valid](https://capsule.clastix.io/docs/general/crds-apis#tenantspecownersindexproxysettingsindex), I think it should be changed to `runtimeClasses` as this better fits the example.

If an issue is needed to merge this PR, I will happily create one. Just let me know.

BR, Lars