### PR TITLE
feat: Allow subjects to act as Owner to bypass the webhook

### DIFF
--- a/api/v1beta2/additional_role_bindings.go
+++ b/api/v1beta2/additional_role_bindings.go
@@ -8,5 +8,6 @@ import rbacv1 "k8s.io/api/rbac/v1"
 type AdditionalRoleBindingsSpec struct {
 	ClusterRoleName string `json:"clusterRoleName"`
 	// kubebuilder:validation:Minimum=1
-	Subjects []rbacv1.Subject `json:"subjects"`
+	Subjects   []rbacv1.Subject `json:"subjects"`
+	ActAsOwner bool             `json:"actAsOwner"`
 }

--- a/charts/capsule/crds/capsule.clastix.io_tenants.yaml
+++ b/charts/capsule/crds/capsule.clastix.io_tenants.yaml
@@ -68,6 +68,8 @@ spec:
                   the RoleBinding for the given ClusterRole. Optional.
                 items:
                   properties:
+                    actAsOwner:
+                      type: boolean
                     clusterRoleName:
                       type: string
                     subjects:
@@ -103,6 +105,7 @@ spec:
                         x-kubernetes-map-type: atomic
                       type: array
                   required:
+                  - actAsOwner
                   - clusterRoleName
                   - subjects
                   type: object
@@ -1093,6 +1096,8 @@ spec:
                   the RoleBinding for the given ClusterRole. Optional.
                 items:
                   properties:
+                    actAsOwner:
+                      type: boolean
                     clusterRoleName:
                       type: string
                     subjects:
@@ -1128,6 +1133,7 @@ spec:
                         x-kubernetes-map-type: atomic
                       type: array
                   required:
+                  - actAsOwner
                   - clusterRoleName
                   - subjects
                   type: object

--- a/docs/content/general/crds-apis.md
+++ b/docs/content/general/crds-apis.md
@@ -1652,6 +1652,11 @@ Optional.<br/>
           kubebuilder:validation:Minimum=1<br/>
         </td>
         <td>true</td>
+      </tr><tr>
+        <td><b>actAsOwner</b></td>
+        <td>bool</td>
+        <td>If subject is treated as owner for namespace creation by admission webhook. Subject still requires permission from RBAC</td>
+        <td>false<td>
       </tr></tbody>
 </table>
 

--- a/pkg/api/additional_role_bindings.go
+++ b/pkg/api/additional_role_bindings.go
@@ -10,5 +10,6 @@ import rbacv1 "k8s.io/api/rbac/v1"
 type AdditionalRoleBindingsSpec struct {
 	ClusterRoleName string `json:"clusterRoleName"`
 	// kubebuilder:validation:Minimum=1
-	Subjects []rbacv1.Subject `json:"subjects"`
+	Subjects   []rbacv1.Subject `json:"subjects"`
+	ActAsOwner bool             `json:"actAsOwner"`
 }

--- a/pkg/webhook/ownerreference/patching.go
+++ b/pkg/webhook/ownerreference/patching.go
@@ -153,8 +153,8 @@ func (h *handler) setOwnerRef(ctx context.Context, req admission.Request, client
 
 			return &response
 		}
-		// Tenant owner must adhere to user that asked for NS creation
-		if !utils.IsTenantOwner(tnt.Spec.Owners, req.UserInfo) {
+		// Tenant owner must adhere to user that asked for NS creation or a subject in the Tenant's AdditionalRoleBindings with ActAsTenantOwner
+		if !utils.IsTenantOwner(tnt.Spec.Owners, req.UserInfo) && !utils.IsActAsTenantOwner(tnt.Spec.AdditionalRoleBindings, req.UserInfo) {
 			recorder.Eventf(tnt, corev1.EventTypeWarning, "NonOwnedTenant", "Namespace %s cannot be assigned to the current Tenant", ns.GetName())
 
 			response := admission.Denied("Cannot assign the desired namespace to a non-owned Tenant")

--- a/pkg/webhook/utils/is_act_as_tenant_owner.go
+++ b/pkg/webhook/utils/is_act_as_tenant_owner.go
@@ -1,0 +1,34 @@
+// Copyright 2020-2023 Project Capsule Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	authenticationv1 "k8s.io/api/authentication/v1"
+
+	capsulev1beta2 "github.com/projectcapsule/capsule/api/v1beta2"
+	"github.com/projectcapsule/capsule/pkg/api"
+)
+
+func IsActAsTenantOwner(additionalRoleBindings []api.AdditionalRoleBindingsSpec, userInfo authenticationv1.UserInfo) bool {
+	for _, additionalRoleBinding := range additionalRoleBindings {
+		if additionalRoleBinding.ActAsOwner {
+			for _, subject := range additionalRoleBinding.Subjects {
+				switch subject.Kind {
+				case string(capsulev1beta2.UserOwner), string(capsulev1beta2.ServiceAccountOwner):
+					if userInfo.Username == subject.Name {
+						return true
+					}
+				case string(capsulev1beta2.GroupOwner):
+					for _, group := range userInfo.Groups {
+						if group == subject.Name {
+							return true
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
As a group of us have been discussing here: https://github.com/projectcapsule/capsule/discussions/1311

This feature adds a new flag in `additionalRoleBindings` which allows the subject to `actAsOwner`.
When a namespace is created, Capsule checks if the requester is owner of the Tenant, or if the Tenant has the `actAsOwner` flag set to true.
If so, the requester is allowed to create the namespace.

Here is a the Tenant used for testing:

```yaml
apiVersion: capsule.clastix.io/v1beta2
kind: Tenant
metadata:
  name: oil
spec:
  owners:
  - name: alice
    kind: User
  - name: system:serviceaccount:tenant-system:tenant-gitops
    kind: ServiceAccount
  additionalRoleBindings:
    - clusterRoleName: admin
      actAsOwner: true # This is how the code is made in this PR
      subjects:
        - name: tenant-gitops
          kind: ServiceAccount
```

While this PR was being developed, we had a talk about what `actAsOwner` means. And where it should be.
In the discussion we aired a few places, and talked about the differences between them.

We believe the name and placement, should reflect what a delveoper would expect it to do.
And so we came up with a new idea, which would fit more in with the default of how the `owners` field works.
I'll paste a yaml example of how it could look like:

```yaml
apiVersion: capsule.clastix.io/v1beta2
kind: Tenant
metadata:
  name: oil
spec:
  owners:
  - name: alice
    kind: User
  - name: system:serviceaccount:tenant-system:tenant-gitops
    kind: ServiceAccount
  additionalRoleBindings:
    - clusterRoleName: admin
      subjects:
        - name: tenant-gitops
          kind: ServiceAccount
  nameSpaceProvisioner: # This is the new field
    subjects:
        - name: tenant-gitops
          kind: ServiceAccount
          clusterRoleName: admin # If this is not set, it could default to a role simmilar to `capsule-namespace-provisioner`
```

The pros of the solution as it is this PR, the flag would be set, in the same place as the rolebindings are set.
The also means if the role giving does not have the RBAC to create a namespace, it would not be able to create a namespace.

In the second solution, the `nameSpaceProvisioner` would be a new field, which would be a list of subjects, which would be allowed to create namespaces.
This would match how `owners` works, and would be more intuitive for a developer to understand.

I would like to hear your thoughts on this, and if you have any other ideas on how to implement this feature.
The PR is set to WIP, as I still don't think we have settled on the best solution. And I think it's better to talk from code.