### PR TITLE
chore(repo): add pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,52 @@
+repos:
+- repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+  rev: v9.20.0
+  hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ['@commitlint/config-conventional', 'commitlint-plugin-function-rules']
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v3.2.0
+  hooks:
+  - id: check-executables-have-shebangs
+  - id: check-yaml
+  - id: double-quote-string-fixer
+  - id: end-of-file-fixer
+  - id: trailing-whitespace
+- repo: local
+  hooks:
+    - id: run-helm-docs
+      name: Execute helm-docs
+      entry: make helm-docs
+      language: system
+      files: ^charts/
+    - id: run-helm-schema
+      name: Execute helm-schema
+      entry: make helm-schema
+      language: system
+      files: ^charts/
+    - id: run-helm-lint
+      name: Execute helm-lint
+      entry: make helm-lint
+      language: system
+      files: ^charts/
+    - id: golangci-lint
+      name: Execute golangci-lint
+      entry: make golint
+      language: system
+      files: \.go$
+- repo: https://github.com/tekwizely/pre-commit-golang
+  rev: v1.0.0-rc.1
+  hooks:
+  - id: go-vet
+  - id: go-vet-mod
+  - id: go-vet-pkg
+  - id: go-vet-repo-mod
+  - id: go-vet-repo-pkg
+  - id: go-revive
+  - id: go-revive-mod
+  - id: go-revive-repo-mod
+  - id: go-sec-mod
+  - id: go-sec-pkg
+  - id: go-sec-repo-mod
+  - id: go-sec-repo-pkg

--- a/charts/capsule/.schema.yaml
+++ b/charts/capsule/.schema.yaml
@@ -1,0 +1,4 @@
+input:
+  - values.yaml
+  - ci/test-values.yaml
+  - ci/proxy-values.yaml

--- a/charts/capsule/values.schema.json
+++ b/charts/capsule/values.schema.json
@@ -1,0 +1,794 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "affinity": {
+            "properties": {},
+            "type": "object"
+        },
+        "certManager": {
+            "properties": {
+                "additionalSANS": {
+                    "type": "array"
+                },
+                "generateCertificates": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "crds": {
+            "properties": {
+                "annnotations": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "exclusive": {
+                    "type": "boolean"
+                },
+                "install": {
+                    "type": "boolean"
+                },
+                "labels": {
+                    "properties": {},
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "customAnnotations": {
+            "properties": {},
+            "type": "object"
+        },
+        "customLabels": {
+            "properties": {},
+            "type": "object"
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "global": {
+            "properties": {
+                "jobs": {
+                    "properties": {
+                        "kubectl": {
+                            "properties": {
+                                "affinity": {
+                                    "properties": {},
+                                    "type": "object"
+                                },
+                                "annotations": {
+                                    "properties": {},
+                                    "type": "object"
+                                },
+                                "backoffLimit": {
+                                    "type": "integer"
+                                },
+                                "image": {
+                                    "properties": {
+                                        "pullPolicy": {
+                                            "type": "string"
+                                        },
+                                        "registry": {
+                                            "type": "string"
+                                        },
+                                        "repository": {
+                                            "type": "string"
+                                        },
+                                        "tag": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "imagePullSecrets": {
+                                    "type": "array"
+                                },
+                                "nodeSelector": {
+                                    "properties": {},
+                                    "type": "object"
+                                },
+                                "podSecurityContext": {
+                                    "properties": {
+                                        "seccompProfile": {
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "priorityClassName": {
+                                    "type": "string"
+                                },
+                                "resources": {
+                                    "properties": {},
+                                    "type": "object"
+                                },
+                                "restartPolicy": {
+                                    "type": "string"
+                                },
+                                "securityContext": {
+                                    "properties": {
+                                        "allowPrivilegeEscalation": {
+                                            "type": "boolean"
+                                        },
+                                        "capabilities": {
+                                            "properties": {
+                                                "drop": {
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "readOnlyRootFilesystem": {
+                                            "type": "boolean"
+                                        },
+                                        "runAsGroup": {
+                                            "type": "integer"
+                                        },
+                                        "runAsNonRoot": {
+                                            "type": "boolean"
+                                        },
+                                        "runAsUser": {
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "tolerations": {
+                                    "type": "array"
+                                },
+                                "topologySpreadConstraints": {
+                                    "type": "array"
+                                },
+                                "ttlSecondsAfterFinished": {
+                                    "type": "integer"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "imagePullSecrets": {
+            "type": "array"
+        },
+        "jobs": {
+            "properties": {},
+            "type": "object"
+        },
+        "manager": {
+            "properties": {
+                "hostNetwork": {
+                    "type": "boolean"
+                },
+                "image": {
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "registry": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "kind": {
+                    "type": "string"
+                },
+                "livenessProbe": {
+                    "properties": {
+                        "httpGet": {
+                            "properties": {
+                                "path": {
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "options": {
+                    "properties": {
+                        "capsuleConfiguration": {
+                            "type": "string"
+                        },
+                        "capsuleUserGroups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "forceTenantPrefix": {
+                            "type": "boolean"
+                        },
+                        "generateCertificates": {
+                            "type": "boolean"
+                        },
+                        "logLevel": {
+                            "type": "string"
+                        },
+                        "nodeMetadata": {
+                            "properties": {
+                                "forbiddenAnnotations": {
+                                    "properties": {
+                                        "denied": {
+                                            "type": "array"
+                                        },
+                                        "deniedRegex": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "forbiddenLabels": {
+                                    "properties": {
+                                        "denied": {
+                                            "type": "array"
+                                        },
+                                        "deniedRegex": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "protectedNamespaceRegex": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "rbac": {
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "existingClusterRoles": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "existingRoles": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "readinessProbe": {
+                    "properties": {
+                        "httpGet": {
+                            "properties": {
+                                "path": {
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "resources": {
+                    "properties": {
+                        "requests": {
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "webhookPort": {
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        },
+        "nodeSelector": {
+            "properties": {},
+            "type": "object"
+        },
+        "podAnnotations": {
+            "properties": {},
+            "type": "object"
+        },
+        "podSecurityContext": {
+            "properties": {
+                "runAsGroup": {
+                    "type": "integer"
+                },
+                "runAsNonRoot": {
+                    "type": "boolean"
+                },
+                "runAsUser": {
+                    "type": "integer"
+                },
+                "seccompProfile": {
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "priorityClassName": {
+            "type": "string"
+        },
+        "proxy": {
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "replicaCount": {
+            "type": "integer"
+        },
+        "securityContext": {
+            "properties": {
+                "allowPrivilegeEscalation": {
+                    "type": "boolean"
+                },
+                "capabilities": {
+                    "properties": {
+                        "drop": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "readOnlyRootFilesystem": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "serviceAccount": {
+            "properties": {
+                "annotations": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "create": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "serviceMonitor": {
+            "properties": {
+                "annotations": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "endpoint": {
+                    "properties": {
+                        "interval": {
+                            "type": "string"
+                        },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
+                        "relabelings": {
+                            "type": "array"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "labels": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "matchLabels": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "targetLabels": {
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "tls": {
+            "properties": {
+                "create": {
+                    "type": "boolean"
+                },
+                "enableController": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "tolerations": {
+            "type": "array"
+        },
+        "topologySpreadConstraints": {
+            "type": "array"
+        },
+        "webhooks": {
+            "properties": {
+                "exclusive": {
+                    "type": "boolean"
+                },
+                "hooks": {
+                    "properties": {
+                        "cordoning": {
+                            "properties": {
+                                "failurePolicy": {
+                                    "type": "string"
+                                },
+                                "namespaceSelector": {
+                                    "properties": {
+                                        "matchExpressions": {
+                                            "items": {
+                                                "properties": {
+                                                    "key": {
+                                                        "type": "string"
+                                                    },
+                                                    "operator": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "defaults": {
+                            "properties": {
+                                "ingress": {
+                                    "properties": {
+                                        "failurePolicy": {
+                                            "type": "string"
+                                        },
+                                        "namespaceSelector": {
+                                            "properties": {
+                                                "matchExpressions": {
+                                                    "items": {
+                                                        "properties": {
+                                                            "key": {
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "pods": {
+                                    "properties": {
+                                        "failurePolicy": {
+                                            "type": "string"
+                                        },
+                                        "namespaceSelector": {
+                                            "properties": {
+                                                "matchExpressions": {
+                                                    "items": {
+                                                        "properties": {
+                                                            "key": {
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "pvc": {
+                                    "properties": {
+                                        "failurePolicy": {
+                                            "type": "string"
+                                        },
+                                        "namespaceSelector": {
+                                            "properties": {
+                                                "matchExpressions": {
+                                                    "items": {
+                                                        "properties": {
+                                                            "key": {
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "ingresses": {
+                            "properties": {
+                                "failurePolicy": {
+                                    "type": "string"
+                                },
+                                "namespaceSelector": {
+                                    "properties": {
+                                        "matchExpressions": {
+                                            "items": {
+                                                "properties": {
+                                                    "key": {
+                                                        "type": "string"
+                                                    },
+                                                    "operator": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "namespaceOwnerReference": {
+                            "properties": {
+                                "failurePolicy": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "namespaces": {
+                            "properties": {
+                                "failurePolicy": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "networkpolicies": {
+                            "properties": {
+                                "failurePolicy": {
+                                    "type": "string"
+                                },
+                                "namespaceSelector": {
+                                    "properties": {
+                                        "matchExpressions": {
+                                            "items": {
+                                                "properties": {
+                                                    "key": {
+                                                        "type": "string"
+                                                    },
+                                                    "operator": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "nodes": {
+                            "properties": {
+                                "failurePolicy": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "persistentvolumeclaims": {
+                            "properties": {
+                                "failurePolicy": {
+                                    "type": "string"
+                                },
+                                "namespaceSelector": {
+                                    "properties": {
+                                        "matchExpressions": {
+                                            "items": {
+                                                "properties": {
+                                                    "key": {
+                                                        "type": "string"
+                                                    },
+                                                    "operator": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "pods": {
+                            "properties": {
+                                "failurePolicy": {
+                                    "type": "string"
+                                },
+                                "namespaceSelector": {
+                                    "properties": {
+                                        "matchExpressions": {
+                                            "items": {
+                                                "properties": {
+                                                    "key": {
+                                                        "type": "string"
+                                                    },
+                                                    "operator": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "services": {
+                            "properties": {
+                                "failurePolicy": {
+                                    "type": "string"
+                                },
+                                "namespaceSelector": {
+                                    "properties": {
+                                        "matchExpressions": {
+                                            "items": {
+                                                "properties": {
+                                                    "key": {
+                                                        "type": "string"
+                                                    },
+                                                    "operator": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "tenantResourceObjects": {
+                            "properties": {
+                                "failurePolicy": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "tenants": {
+                            "properties": {
+                                "failurePolicy": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "mutatingWebhooksTimeoutSeconds": {
+                    "type": "integer"
+                },
+                "service": {
+                    "properties": {
+                        "caBundle": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "null"
+                        },
+                        "url": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "validatingWebhooksTimeoutSeconds": {
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "type": "object"
+}


### PR DESCRIPTION
<!--
Read the contribution guidelines before creating a pull request.

https://github.com/projectcapsule/capsule/blob/main/CONTRIBUTING.md

Thanks for spending some time for improving and fixing Capsule!
-->

I have noticed a lot of users having troubles with commit messaging etc. For first time contributors they have to wait until we approve the runs again. To prevent this, i have added some pre-commit hooks which keep the semantics of files clean, check commit messages, generate helm related stuff, and lint the code. This helps users to detect errors already locally without any further action.

I have also added a schema (schema generator target) for our helm chart.
