### PR TITLE
feat(helm): Added health port in ClusterIP

### DIFF
--- a/charts/capsule/templates/deployment.yaml
+++ b/charts/capsule/templates/deployment.yaml
@@ -89,6 +89,9 @@ spec:
             - name: metrics
               containerPort: 8080
               protocol: TCP
+            - name: health-api
+              containerPort: 10080
+              protocol: TCP
             {{- end }}
             {{- with .Values.manager.ports }}
               {{- . | nindent 12 }}

--- a/charts/capsule/templates/metrics-service.yaml
+++ b/charts/capsule/templates/metrics-service.yaml
@@ -15,6 +15,10 @@ spec:
     name: metrics
     protocol: TCP
     targetPort: 8080
+  - port: 10080
+    name: health-api
+    protocol: TCP
+    targetPort: 10080
   selector:
     {{- include "capsule.selectorLabels" . | nindent 4 }}
   sessionAffinity: None


### PR DESCRIPTION
Description
This PR adds a health check port to the Helm chart's ClusterIP service definition. This enables external systems (e.g., Prometheus, Kubernetes probes) to perform liveness/readiness checks on the service more effectively.

Changes
Added health port under spec.ports in the service template.

Ensured backwards compatibility with existing deployments.

Motivation
Adding this port allows for better observability and integration with monitoring tools, and ensures the service can be properly health-checked.