### PR TITLE
feat: add toggle for securitycontext and podsecuritycontext

### DIFF
--- a/charts/capsule/Chart.yaml
+++ b/charts/capsule/Chart.yaml
@@ -41,4 +41,4 @@ annotations:
       url: https://projectcapsule.dev/
   artifacthub.io/changes: |
     - kind: added
-      description: oci chart reference
+      description: added toggles for podSecurityContexts and securityContexts

--- a/charts/capsule/README.md
+++ b/charts/capsule/README.md
@@ -108,11 +108,11 @@ Here the values you can override:
 | global.jobs.kubectl.image.tag | string | `""` | Set the image tag of the helm chart job |
 | global.jobs.kubectl.imagePullSecrets | list | `[]` | ImagePullSecrets |
 | global.jobs.kubectl.nodeSelector | object | `{}` | Set the node selector |
-| global.jobs.kubectl.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the job pods. |
+| global.jobs.kubectl.podSecurityContext | object | `{"enabled":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the job pods. |
 | global.jobs.kubectl.priorityClassName | string | `""` | Set a pod priorityClassName |
 | global.jobs.kubectl.resources | object | `{}` | Job resources |
 | global.jobs.kubectl.restartPolicy | string | `"Never"` | Set the restartPolicy |
-| global.jobs.kubectl.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":1002,"runAsNonRoot":true,"runAsUser":1002}` | Security context for the job containers. |
+| global.jobs.kubectl.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"enabled":true,"readOnlyRootFilesystem":true,"runAsGroup":1002,"runAsNonRoot":true,"runAsUser":1002}` | Security context for the job containers. |
 | global.jobs.kubectl.tolerations | list | `[]` | Set list of tolerations |
 | global.jobs.kubectl.topologySpreadConstraints | list | `[]` | Set Topology Spread Constraints |
 | global.jobs.kubectl.ttlSecondsAfterFinished | int | `60` | Sets the ttl in seconds after a finished certgen job is deleted. Set to -1 to never delete. |
@@ -130,7 +130,7 @@ Here the values you can override:
 | jobs | object | `{}` | Deprecated, use .global.jobs.kubectl instead |
 | nodeSelector | object | `{}` | Set the node selector for the Capsule pod |
 | podAnnotations | object | `{}` | Annotations to add to the capsule pod. |
-| podSecurityContext | object | `{"runAsGroup":1002,"runAsNonRoot":true,"runAsUser":1002,"seccompProfile":{"type":"RuntimeDefault"}}` | Set the securityContext for the Capsule pod |
+| podSecurityContext | object | `{"enabled":true,"runAsGroup":1002,"runAsNonRoot":true,"runAsUser":1002,"seccompProfile":{"type":"RuntimeDefault"}}` | Set the securityContext for the Capsule pod |
 | ports | list | `[]` | Set additional ports for the deployment |
 | priorityClassName | string | `""` | Set the priority class name of the Capsule pod |
 | proxy.enabled | bool | `false` | Enable Installation of Capsule Proxy |
@@ -139,7 +139,7 @@ Here the values you can override:
 | rbac.resources.create | bool | `false` |  |
 | rbac.resources.labels."rbac.authorization.k8s.io/aggregate-to-admin" | string | `"true"` |  |
 | replicaCount | int | `1` | Set the replica count for capsule pod |
-| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Set the securityContext for the Capsule container |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"enabled":true,"readOnlyRootFilesystem":true}` | Set the securityContext for the Capsule container |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and `serviceAccount.create=true`, a name is generated using the fullname template |

--- a/charts/capsule/templates/crd-lifecycle/job.yaml
+++ b/charts/capsule/templates/crd-lifecycle/job.yaml
@@ -28,9 +28,8 @@ spec:
         {{- include "capsule.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: {{ $Values.restartPolicy }}
-      {{- with $Values.podSecurityContext }}
-      securityContext:
-        {{- toYaml . | nindent 8 }}
+      {{- if $Values.podSecurityContext.enabled }}
+      securityContext: {{- omit $Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       {{- with $Values.nodeSelector }}
       nodeSelector:
@@ -60,9 +59,8 @@ spec:
       - name: crds-hook
         image: {{ include "capsule.jobsFullyQualifiedDockerImage" . }}
         imagePullPolicy: {{ $Values.image.pullPolicy }}
-        {{- with $Values.securityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
+        {{- if $Values.securityContext.enabled }}
+        securityContext: {{- omit $Values.securityContext "enabled" | toYaml | nindent 10 }}
         {{- end }}
         command:
         - sh

--- a/charts/capsule/templates/daemonset.yaml
+++ b/charts/capsule/templates/daemonset.yaml
@@ -30,9 +30,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "capsule.serviceAccountName" . }}
-      {{- with .Values.podSecurityContext }}
-      securityContext:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       {{- if .Values.manager.hostNetwork }}
       hostNetwork: true
@@ -87,7 +86,8 @@ spec:
             readOnly: true
           resources:
             {{- toYaml .Values.manager.resources | nindent 12 }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.securityContext.enabled }}
+          securityContext: {{- omit .Values.securityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/capsule/templates/deployment.yaml
+++ b/charts/capsule/templates/deployment.yaml
@@ -29,9 +29,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "capsule.serviceAccountName" . }}
-      {{- with .Values.podSecurityContext }}
-      securityContext:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       {{- if .Values.manager.hostNetwork }}
       hostNetwork: true
@@ -109,11 +108,10 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.manager.resources | nindent 12 }}
-          securityContext:
-            {{- if .Values.manager.securityContext }}
-            {{- toYaml .Values.manager.securityContext | nindent 12 }}
-            {{- else }}
-            {{- toYaml .Values.securityContext | nindent 12 }}
-            {{- end }}
+          {{- if .Values.manager.securityContext }}
+          securityContext: {{- omit .Values.manager.securityContext "enabled" | toYaml | nindent 12 }}
+          {{- else if .Values.securityContext.enabled }}
+          securityContext: {{- omit .Values.securityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/capsule/templates/post-install/job.yaml
+++ b/charts/capsule/templates/post-install/job.yaml
@@ -25,9 +25,8 @@ spec:
         {{- include "capsule.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: {{ $Values.restartPolicy }}
-      {{- with $Values.podSecurityContext }}
-      securityContext:
-        {{- toYaml . | nindent 8 }}
+      {{- if $Values.podSecurityContext.enabled }}
+      securityContext: {{- omit $Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       {{- with $Values.nodeSelector }}
       nodeSelector:
@@ -70,9 +69,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- with $Values.securityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
+        {{- if $Values.securityContext.enabled }}
+        securityContext: {{- omit $Values.securityContext "enabled" | toYaml | nindent 10 }}
         {{- end }}
         {{- with $Values.resources }}
         resources:

--- a/charts/capsule/templates/pre-delete/job.yaml
+++ b/charts/capsule/templates/pre-delete/job.yaml
@@ -25,9 +25,8 @@ spec:
         {{- include "capsule.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: {{ $Values.restartPolicy }}
-      {{- with $Values.podSecurityContext }}
-      securityContext:
-        {{- toYaml . | nindent 8 }}
+      {{- if $Values.podSecurityContext.enabled }}
+      securityContext: {{- omit $Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       {{- with $Values.nodeSelector }}
       nodeSelector:
@@ -72,9 +71,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          {{- with $Values.securityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
+          {{- if $Values.securityContext.enabled }}
+          securityContext: {{- omit $Values.securityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           {{- with $Values.resources }}
           resources:

--- a/charts/capsule/values.schema.json
+++ b/charts/capsule/values.schema.json
@@ -102,6 +102,9 @@
                                     "description": "Security context for the job pods.",
                                     "type": "object",
                                     "properties": {
+                                        "enabled": {
+                                            "type": "boolean"
+                                        },
                                         "seccompProfile": {
                                             "type": "object",
                                             "properties": {
@@ -141,6 +144,9 @@
                                                     }
                                                 }
                                             }
+                                        },
+                                        "enabled": {
+                                            "type": "boolean"
                                         },
                                         "readOnlyRootFilesystem": {
                                             "type": "boolean"
@@ -464,6 +470,9 @@
             "description": "Set the securityContext for the Capsule pod",
             "type": "object",
             "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
                 "runAsGroup": {
                     "type": "integer"
                 },
@@ -558,6 +567,9 @@
                             }
                         }
                     }
+                },
+                "enabled": {
+                    "type": "boolean"
                 },
                 "readOnlyRootFilesystem": {
                     "type": "boolean"

--- a/charts/capsule/values.yaml
+++ b/charts/capsule/values.yaml
@@ -24,10 +24,12 @@ global:
       ttlSecondsAfterFinished: 60
       # -- Security context for the job pods.
       podSecurityContext:
+        enabled: true
         seccompProfile:
           type: "RuntimeDefault"
       # -- Security context for the job containers.
       securityContext:
+        enabled: true
         allowPrivilegeEscalation: false
         capabilities:
           drop:
@@ -192,6 +194,7 @@ priorityClassName: '' # system-cluster-critical
 
 # -- Set the securityContext for the Capsule pod
 podSecurityContext:
+  enabled: true
   seccompProfile:
     type: "RuntimeDefault"
   runAsGroup: 1002
@@ -200,6 +203,7 @@ podSecurityContext:
 
 # -- Set the securityContext for the Capsule container
 securityContext:
+  enabled: true
   capabilities:
     drop:
     - ALL


### PR DESCRIPTION
Added toggles for enabling/disabling securityContext and PodSecurityContext. If you have other security measurements in place (for example Openshift SCC's), the default SecurityContexts are not needed. In the past, we provided an empty string for the securityContext, which always worked. But suddenly, ArgoCD does not accept this anymore. So, adding a toggle for this.

(This is the same change as added in the [sops-operator](https://github.com/peak-scale/sops-operator/pull/90) and [capsule-proxy](https://github.com/projectcapsule/capsule-proxy/pull/796) )
