### PR TITLE
fix(tenantresource): ensure original map is not modified in prepareAd…

### DIFF
--- a/controllers/resources/processor.go
+++ b/controllers/resources/processor.go
@@ -40,7 +40,12 @@ func prepareAdditionalMetadata(m map[string]string) map[string]string {
 		return make(map[string]string)
 	}
 
-	return m
+	// we need to create a new map to avoid modifying the original one
+	copied := make(map[string]string, len(m))
+	for k, v := range m {
+		copied[k] = v
+	}
+	return copied
 }
 
 func (r *Processor) HandlePruning(ctx context.Context, current, desired sets.Set[string]) (updateStatus bool) {


### PR DESCRIPTION
Saw that the original map was returned when `additionalMetadata` was specified leading to the controller adding the labels and annotations as specified here: https://github.com/projectcapsule/capsule/blob/v0.10.0/controllers/resources/processor.go#L133 to the `globaltenantresource.spec.resources.additionalMetadata`. 

I made sure to just create a new map and return this instead. 