### PR TITLE
fix: ensure empty arrays rendered for userNames and ignoreUserWithGroups

### DIFF
--- a/charts/capsule/templates/configuration-default.yaml
+++ b/charts/capsule/templates/configuration-default.yaml
@@ -20,13 +20,21 @@ spec:
   {{- range .Values.manager.options.capsuleUserGroups }}
     - {{ . }}
   {{- end }}
+  {{- if .Values.manager.options.userNames }}
   userNames:
   {{- range .Values.manager.options.userNames }}
     - {{ . }}
   {{- end }}
+  {{- else }}
+  userNames: []
+  {{- end }}
+  {{- if .Values.manager.options.ignoreUserWithGroups }}
   ignoreUserWithGroups:
   {{- range .Values.manager.options.ignoreUserWithGroups }}
     - {{ . }}
+  {{- end }}
+  {{- else }}
+  ignoreUserWithGroups: []
   {{- end }}
   protectedNamespaceRegex: {{ .Values.manager.options.protectedNamespaceRegex | quote }}
   {{- with .Values.manager.options.nodeMetadata }}


### PR DESCRIPTION
Without this fix, Helm emits null when userNames or ignoreUserWithGroups are empty or unset. This breaks CRD validation (e.g. in Argo CD) because the CapsuleConfiguration schema requires arrays if the keys are present. This patch ensures valid YAML by defaulting to empty arrays.