### PR TITLE
feat: enabled multiple endpoints in servicemonitor

### DIFF
--- a/charts/capsule/templates/servicemonitor.yaml
+++ b/charts/capsule/templates/servicemonitor.yaml
@@ -17,23 +17,35 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-  {{- with .endpoint }}
-  - interval: {{ .interval }}
-    port: metrics
-    path: /metrics
-    {{- with .scrapeTimeout }}
-    scrapeTimeout: {{ . }}
+  {{- range .endpoints }}
+  - {{- if .port }}
+    port: {{ .port }}
+    {{- end }}
+    {{- if .interval }}
+    interval: {{ .interval }}
+    {{- end }}
+    {{- if .path }}
+    path: {{ .path }}
+    {{- end }}
+    {{- if .scheme }}
+    scheme: {{ .scheme }}
+    {{- end }}
+    {{- if .scrapeTimeout }}
+    scrapeTimeout: {{ .scrapeTimeout }}
+    {{- end }}
+    {{- with .params }}
+    params: {{ toYaml . | nindent 6 }}
     {{- end }}
     {{- with .metricRelabelings }}
-    metricRelabelings: {{- toYaml . | nindent 6 }}
+    metricRelabelings: {{ toYaml . | nindent 6 }}
     {{- end }}
     {{- with .relabelings }}
-    relabelings: {{- toYaml . | nindent 6 }}
+    relabelings: {{ toYaml . | nindent 6 }}
     {{- end }}
   {{- end }}
   jobLabel: app.kubernetes.io/name
   {{- with .targetLabels }}
-  targetLabels: {{- toYaml . | nindent 4 }}
+  targetLabels: {{ toYaml . | nindent 4 }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/capsule/values.yaml
+++ b/charts/capsule/values.yaml
@@ -322,28 +322,50 @@ monitoring:
       folder: ""
 
   # ServiceMonitor
-  serviceMonitor:
-    # -- Enable ServiceMonitor
-    enabled: false
-    # -- Install the ServiceMonitor into a different Namespace, as the monitoring stack one (default: the release one)
-    namespace: ''
-    # -- Assign additional labels according to Prometheus' serviceMonitorSelector matching labels
-    labels: {}
-    # -- Assign additional Annotations
-    annotations: {}
-    # -- Change matching labels
-    matchLabels: {}
-    # -- Set targetLabels for the serviceMonitor
-    targetLabels: []
-    endpoint:
-      # -- Set the scrape interval for the endpoint of the serviceMonitor
-      interval: "15s"
-      # -- Set the scrape timeout for the endpoint of the serviceMonitor
+# ServiceMonitor
+serviceMonitor:
+  # -- Enable ServiceMonitor
+  enabled: true
+
+  # -- Install the ServiceMonitor into a different Namespace, as the monitoring stack one (default: the release one)
+  namespace: ''
+
+  # -- Assign additional labels according to Prometheus' serviceMonitorSelector matching labels
+  labels: {}
+
+  # -- Assign additional Annotations
+  annotations: {}
+
+  # -- Change matching labels
+  matchLabels: {}
+
+  # -- Set targetLabels for the serviceMonitor
+  targetLabels: []
+
+  # -- Define multiple scrape endpoints
+  endpoints:
+    # Default metrics scrape
+    - interval: "15s"
       scrapeTimeout: ""
-      # -- Set metricRelabelings for the endpoint of the serviceMonitor
       metricRelabelings: []
-      # -- Set relabelings for the endpoint of the serviceMonitor
-      relabelings: []
+      relabelings:
+        - targetLabel: instance_name
+          replacement: "demo"
+
+    # # Endpoint-a
+    # - port: http
+    #   interval: 10s
+    #   scrapeTimeout: 5s
+    #   path: /probe
+    #   scheme: http
+
+    # # Endpoint-b
+    # - port: http
+    #   interval: 10s
+    #   scrapeTimeout: 5s
+    #   path: /probe
+    #   scheme: http
+
 
 
 # Webhooks configurations


### PR DESCRIPTION
###  What this PR does

This PR updates the Capsule Helm chart ServiceMonitor template to support multiple endpoints instead of a single .endpoint.

### Why

Currently, the chart only allows defining one .endpoint, which prevents using Prometheus blackbox-exporter probes or scraping additional targets like /healthz and /readyz.

For example, the following configuration in values.yaml does not render correctly today:

`serviceMonitor:
  enabled: true
  endpoints:
    - interval: "15s"
      relabelings:
        - targetLabel: instance_name
          replacement: "demo"
    - port: http
      interval: 10s
      scrapeTimeout: 5s
      path: /probe
      scheme: http
      params:
        module: [http_2xx]
        target: [http://capsule-controller-manager-metrics-service.capsule-system.svc.cluster.local:10080/healthz]
      relabelings:
        - targetLabel: probe_type
          replacement: "livez"
`
### How

Replaced .endpoint with .endpoints in the ServiceMonitor template.

Added a range loop to render each endpoint with support for:

- port

- interval
 
- path
 
- scheme
 
- scrapeTimeout
 
- params
 
- metricRelabelings
 
- relabelings

Ensured backward compatibility by allowing a single-item array in .endpoints.

### Testing

- Verified helm template works with:
    - A single endpoint
    - Multiple endpoints including blackbox-exporter configs

- Confirmed rendered ServiceMonitor CRD validates against monitoring.coreos.com/v1.

### Example Rendered Output
`spec:
  endpoints:
    - interval: 15s
      relabelings:
        - targetLabel: instance_name
          replacement: demo
    - port: http
      interval: 10s
      scrapeTimeout: 5s
      path: /probe
      scheme: http
      params:
        module:
          - http_2xx
        target:
          - http://capsule-controller-manager-metrics-service.capsule-system.svc.cluster.local:10080/healthz
      relabelings:
        - targetLabel: probe_type
          replacement: livez
`

### Checklist

-  Chart template updated

-  values.yaml updated with endpoints examples
 
-  CHANGELOG entry added
 
-  Tested with Prometheus Operator

### Thanks!!