### PR TITLE
fix(docs): add static width per logo for adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -7,43 +7,43 @@ This is a list of companies that have adopted Capsule, feel free to open a Pull-
 ## Adopters list (alphabetically)
 
 ### [Bedag Informatik AG](https://www.bedag.ch/)
-![Bedag](https://www.bedag.ch/wGlobal/wGlobal/layout/images/logo.svg)
+<img src="https://www.bedag.ch/wGlobal/wGlobal/layout/images/logo.svg" alt="Bedag" width="350" />
 
 ### [Department of Defense](https://www.defense.gov/)
-![United States Department of Defense](https://www.access-board.gov/images/dod-seal.png)
+<img src="https://www.access-board.gov/images/dod-seal.png" alt="United States Department of Defense" width="350" />
 
 ### [Enreach](https://www.enreach.com/)
-![Enreach](https://campaigns.enreach.com/hubfs/Global/logos/Enreach-logo-vertical-indigo.svg)
+<img src="https://campaigns.enreach.com/hubfs/Global/logos/Enreach-logo-vertical-indigo.svg" alt="Enreach" width="350" />
 
 ### [Fastweb](https://www.fastweb.it/)
-![Fastweb](https://www.fastweb.it/var/storage_feeds/CMS-Company/articoli/0c2/0c252987b90a18017dedf2ed9feda129/640x360.jpg)
+<img src="https://www.fastweb.it/var/storage_feeds/CMS-Company/articoli/0c2/0c252987b90a18017dedf2ed9feda129/640x360.jpg" alt="Fastweb" width="350" />
 
 ### [Klarrio](https://klarrio.com/)
-![Klarrio](https://klarrio.com/wp-content/uploads/klarrio.png)
+<img src="https://klarrio.com/wp-content/uploads/klarrio.png" alt="Klarrio" width="350" />
 
 ### [KubeRocketCI](https://docs.kuberocketci.io/)
-![KubeRocketCI](https://raw.githubusercontent.com/epam/edp-install/master/docs/assets/krci-logo-267×150-white.png)
+<img src="https://raw.githubusercontent.com/epam/edp-install/master/docs/assets/krci-logo-267×150-white.png" alt="KubeRocketCI" width="350" />
 
 ### [ODC-Noord](https://odc-noord.nl/)
-![ODC-Noord](./assets/customer_logo/odc-noord-logo.png)
+<img src="./assets/customer_logo/odc-noord-logo.png" alt="ODC-Noord" width="350" />
 
 ### [PITS Global Data Recovery Services](https://www.pitsdatarecovery.net)
-![PITS Global Data Recovery Services](https://www.pitsdatarecovery.net/wp-content/uploads/2020/09/pits-logo.svg)
+<img src="https://www.pitsdatarecovery.net/wp-content/uploads/2020/09/pits-logo.svg" alt="PITS Global Data Recovery Services" width="350" />
 
 ### [Politecnico di Torino](https://www.polito.it/)
-![Politecnico di Torino](https://www.polito.it/themes/custom/polito/polito_logo_desktop.svg)
+<img src="https://www.polito.it/themes/custom/polito/polito_logo_desktop.svg" alt="Politecnico di Torino" width="350" />
 
 ### [Reevo](https://www.reevo.it/)
-![Reevo Cloud and CyberSecurity](https://www.reevo.it/hs-fs/hubfs/logo_reevo_azzurro.png)
+<img src="https://www.reevo.it/hs-fs/hubfs/logo_reevo_azzurro.png" alt="Reevo Cloud and CyberSecurity" width="350" />
 
 ### [Seeweb](https://seeweb.it/en)
-![Seeweb x Serverless GPU](https://www.seeweb.it/assets/images/logo-seeweb.svg)
+<img src="https://www.seeweb.it/assets/images/logo-seeweb.svg" alt="Seeweb x Serverless GPU" width="350" />
 
 ### [University of Torino](https://www.unito.it)
-![University of Torino](https://www.unito.it/sites/all/themes/bsunito/img/logo_new_2022.svg)
+<img src="https://www.unito.it/sites/all/themes/bsunito/img/logo_new_2022.svg" alt="University of Torino" width="350" />
 
 ### [Velocity](https://velocity.tech/)
-![Velocity](https://raw.githubusercontent.com/yarelm/velocity-logo/main/velocity.png)
+<img src="https://raw.githubusercontent.com/yarelm/velocity-logo/main/velocity.png" alt="Velocity" width="350" />
 
 ### [Wargaming.net](https://www.wargaming.net/)
-![Wargaming.net](https://download.logo.wine/logo/Wargaming_%28company%29/Wargaming_%28company%29-Logo.wine.png)
+<img src="https://download.logo.wine/logo/Wargaming_%28company%29/Wargaming_%28company%29-Logo.wine.png" alt="Wargaming.net" width="350" />


### PR DESCRIPTION
Just visual, add a static width of 350px to every adopter logo, so the list is easier to read. 