### PR TITLE
fix(chart): add argocd annotations for crd lifecycle job

### DIFF
--- a/charts/capsule/templates/crd-lifecycle/_helpers.tpl
+++ b/charts/capsule/templates/crd-lifecycle/_helpers.tpl
@@ -4,6 +4,7 @@
 
 {{- define "capsule.crds.annotations" -}}
 "helm.sh/hook": "pre-install,pre-upgrade"
+"argocd.argoproj.io/hook": "PreSync"
 {{- end }}
 
 {{- define "capsule.crds.component" -}}


### PR DESCRIPTION
This PR adds an ArgoCD hook annotation to ensure CRDs are created/updated before other resources during ArgoCD deployments.

**Problem**:
When deploying Capsule via ArgoCD, CRDs are applied simultaneously with other resources, causing installation failures when custom resources are processed before CRDs are ready.

**Solution**:
The PreSync hook ensures CRDs are properly installed and available before ArgoCD proceeds with syncing the remaining resources, enabling successful Capsule deployment in ArgoCD-managed clusters.

More informations about ArgoCD sync phases [here](https://argo-cd.readthedocs.io/en/latest/user-guide/sync-waves/)