### PR TITLE
feat: kubernetes health badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@
   </a>
   <a href="https://app.fossa.com/projects/git%2Bgithub.com%2Fprojectcapsule%2Fcapsule?ref=badge_shield&issueType=license" alt="FOSSA Status">
     <img src="https://app.fossa.com/api/projects/git%2Bgithub.com%2Fprojectcapsule%2Fcapsule.svg?type=shield&issueType=license"/>
+  <a href="https://releaserun.com/badges/kubernetes/">
+    <img src="https://img.releaserun.com/badge/health/kubernetes.svg" alt="Kubernetes Health"/>
+  </a>
   </a>
 </p>
 


### PR DESCRIPTION
Adds a Kubernetes health badge from [ReleaseRun](https://releaserun.com) to the README badge row. It shows the current health grade of the Kubernetes platform, updated automatically based on version freshness, CVE status, and end-of-life timeline.

**Badge preview**: ![Kubernetes Health](https://img.releaserun.com/badge/health/kubernetes.svg)

Free, no API key, no config. Fits naturally alongside the existing security scorecard and best practices badges.

Happy to adjust placement or styling if needed.