### PR TITLE
chore(workflows): bump trivy action to 0.35.0

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: ko build
         run: VERSION=${{ github.sha }} make ko-build-all
       - name: Trivy Scan Image
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           build-cache-key: publish-images
       - name: Run Trivy vulnerability (Repo)
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true


### PR DESCRIPTION
This pull request updates the Trivy security scanning action used in the Docker build and publish GitHub workflows to a newer version. This ensures that vulnerability scanning benefits from the latest features and fixes.

**CI/CD workflow updates:**

* Updated the Trivy GitHub Action from version 0.33.1 to 0.35.0 in `.github/workflows/docker-build.yml` to improve security scanning during Docker image builds.
* Updated the Trivy GitHub Action from version 0.33.1 to 0.35.0 in `.github/workflows/docker-publish.yml` to enhance vulnerability scanning during Docker image publishing
