### PR TITLE
fix(webhook): adapt to controller-runtime breaking change in newwebhookmanagedby

### DIFF
--- a/api/v1beta1/tenant_webhook.go
+++ b/api/v1beta1/tenant_webhook.go
@@ -7,9 +7,10 @@ import (
 	"os"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-func (in *Tenant) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (in *Tenant) SetupWebhookWithManager(mgr manager.Manager) error {
 	certData, _ := os.ReadFile("/tmp/k8s-webhook-server/serving-certs/tls.crt")
 	if len(certData) == 0 {
 		return nil


### PR DESCRIPTION
fixes https://github.com/projectcapsule/capsule/issues/1897
Changed the `mgr` parameter type in the `SetupWebhookWithManager` method from `ctrl.Manager` to `manager.Manager` in `tenant_webhook.go` in order to align with the recent changes in `controller-runtime`.