### PR TITLE
ci: pin slsa provenance workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -60,7 +60,7 @@ jobs:
       id-token: write   # To sign the provenance.
       packages: write   # To upload assets to release.
       actions: read     # To read the workflow path.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       image: ghcr.io/${{ github.repository_owner }}/capsule
       digest: "${{ needs.publish-images.outputs.capsule-digest }}"

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -73,7 +73,7 @@ jobs:
       id-token: write   # To sign the provenance.
       packages: write   # To upload assets to release.
       actions: read     # To read the workflow path.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       image: ghcr.io/${{ github.repository_owner }}/charts/capsule
       digest: "${{ needs.publish-helm-oci.outputs.chart-digest }}"


### PR DESCRIPTION
Closes #1899.

Summary:
- Pins the SLSA reusable workflow in the image publish workflow to the v2.1.0 commit SHA.
- Pins the SLSA reusable workflow in the Helm publish workflow to the same commit SHA.
- Keeps the v2.1.0 comments for traceability.

Validation:
- yq . .github/workflows/helm-publish.yml .github/workflows/docker-publish.yml
- rg --pcre2 -n uses check for non-SHA workflow refs
- git diff --check origin/main...HEAD