### PR TITLE
fix: correct helm docs for webhook service port schema

### DIFF
--- a/charts/capsule/README.md
+++ b/charts/capsule/README.md
@@ -73,7 +73,7 @@ The following Values have changed key or Value:
 | conversions.service.caBundle | string | `""` | CABundle for the webhook service |
 | conversions.service.name | string | `""` | Custom service name for the webhook service |
 | conversions.service.namespace | string | `""` | Custom service namespace for the webhook service |
-| conversions.service.port | string | `nil` | Custom service port for the webhook service |
+| conversions.service.port | integer, null | `nil` | Custom service port for the webhook service |
 | conversions.service.url | string | `""` | The URL where the capsule webhook services are running (Overwrites cluster scoped service definition) |
 | customAnnotations | object | `{}` | Additional annotations which will be added to all resources created by Capsule helm chart |
 | customLabels | object | `{}` | Additional labels which will be added to all resources created by Capsule helm chart |
@@ -365,7 +365,7 @@ The following Values have changed key or Value:
 | webhooks.service.caBundle | string | `""` | CABundle for the webhook service |
 | webhooks.service.name | string | `""` | Custom service name for the webhook service |
 | webhooks.service.namespace | string | `""` | Custom service namespace for the webhook service |
-| webhooks.service.port | string | `nil` | Custom service port for the webhook service |
+| webhooks.service.port | integer, null | `nil` | Custom service port for the webhook service |
 | webhooks.service.url | string | `""` | The URL where the capsule webhook services are running (Overwrites cluster scoped service definition) |
 | webhooks.validatingWebhooksTimeoutSeconds | int | `30` | Timeout in seconds for validating webhooks |
 

--- a/charts/capsule/values.schema.json
+++ b/charts/capsule/values.schema.json
@@ -38,7 +38,7 @@
                             "type": "string"
                         },
                         "port": {
-                            "description": "Custom service port for the webhook service",
+                            "description": "(integer, null) Custom service port for the webhook service",
                             "type": [
                                 "integer",
                                 "null"
@@ -2178,7 +2178,7 @@
                             "type": "string"
                         },
                         "port": {
-                            "description": "Custom service port for the webhook service",
+                            "description": "(integer, null) Custom service port for the webhook service",
                             "type": [
                                 "integer",
                                 "null"

--- a/charts/capsule/values.yaml
+++ b/charts/capsule/values.yaml
@@ -465,7 +465,7 @@ conversions:
     name: ""
     # -- Custom service namespace for the webhook service
     namespace: ""
-    # -- Custom service port for the webhook service
+    # -- (integer, null) Custom service port for the webhook service
     port: # @schema type:[integer, null]
 
 
@@ -494,7 +494,7 @@ webhooks:
     name: ""
     # -- Custom service namespace for the webhook service
     namespace: ""
-    # -- Custom service port for the webhook service
+    # -- (integer, null) Custom service port for the webhook service
     port: # @schema type:[integer, null]
 
   # Admission Webhook Configuration


### PR DESCRIPTION
This corrects the helm docs webhook service port documentation.
unfortunately the helm-dos and helm-scheme do not follow the same pattern, hence to get correct types in both schema and docs the declaration need to be redundant.