### PR TITLE
fix(webhook): handle admin updates of tenant-less namespaces (deny + panic regression from #1841)

### DIFF
--- a/internal/webhook/namespace/mutation/handler.go
+++ b/internal/webhook/namespace/mutation/handler.go
@@ -108,6 +108,19 @@ func (h *handler) OnUpdate(
 			return ad.ErroredResponse(err)
 		}
 
+		tnt, err := tenant.GetTenantByLabels(ctx, reader, ns)
+		if err != nil {
+			return ad.ErroredResponse(err)
+		}
+
+		// An admin updating a namespace that belongs to no tenant has nothing to
+		// mutate, so short-circuit and allow it. OnCreate already does this; the
+		// symmetric guard was missing on OnUpdate, which made the sub-handlers
+		// deny admin updates of tenant-less namespaces.
+		if tnt == nil && user.IsAdmin() {
+			return nil
+		}
+
 		for _, hndl := range h.handlers {
 			response := hndl.OnUpdate(c, reader, user, ns, oldNs, decoder, recorder)(ctx, req)
 			if response == nil {

--- a/internal/webhook/namespace/validation/handler.go
+++ b/internal/webhook/namespace/validation/handler.go
@@ -159,6 +159,7 @@ func (h *handler) OnUpdate(
 			return ad.ErroredResponse(err)
 		}
 
+		tnt := newTenant
 		if !user.IsAdmin() {
 			if oldTenant == nil || newTenant == nil {
 				return ad.Deny("namespace tenant ownership is incomplete")
@@ -181,19 +182,16 @@ func (h *handler) OnUpdate(
 
 				return ad.Deny("denied patch request for this namespace")
 			}
-		}
 
-		if terminating := h.rejectOnTermination(ctx, c, ns, newTenant); terminating != nil {
-			return terminating
-		}
-
-		tnt := newTenant
-		if !user.IsAdmin() {
 			tnt = oldTenant
 		}
 
 		if tnt == nil {
 			return nil
+		}
+
+		if terminating := h.rejectOnTermination(ctx, c, ns, tnt); terminating != nil {
+			return terminating
 		}
 
 		for _, hndl := range h.handlers {


### PR DESCRIPTION
<!--
Read the contribution guidelines before creating a pull request.

https://github.com/projectcapsule/capsule/blob/main/CONTRIBUTING.md

Thanks for spending some time for improving and fixing Capsule!
-->
## Summary

Since #1841 (`cc4fb45`), an admin updating a namespace that does not belong to
any tenant is broken in two ways:

1. The **mutating** webhook denies the request with `Unable to assign namespace to tenant`.
2. The **validating** webhook **panics** with a nil pointer dereference (HTTP 500)
   once the mutating webhook is bypassed/fixed.

## Reproduction

```
# as an admin user
$ kubectl create namespace foo
$ kubectl label namespace foo bar=baz          # foo has no tenant, user is cluster-admin
# mutating webhook:
Error from server (Forbidden): admission webhook "namespaces.tenants.projectcapsule.dev"
denied the request: Unable to assign namespace to tenant.

# once the mutating webhook allows it, the validating webhook panics:
Error from server: admission webhook "namespaces.projectcapsule.dev" denied the request:
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
```

## Fix

Mirror the existing `OnCreate` handling into `OnUpdate`, in both webhooks.

## Testing

Tested with a prebuilt image with this patch (available at `docker.io/jouve/capsule:v0.13.1-fix5`).