### PR TITLE
chore: move controller main to cmd/controller

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,7 +51,7 @@ jobs:
           sbom-name: capsule
           sbom-repository: ghcr.io/${{ github.repository_owner }}/capsule
           signature-repository: ghcr.io/${{ github.repository_owner }}/capsule
-          main-path: ./cmd/
+          main-path: ./cmd/controller/
         env:
           REPOSITORY: ${{ github.repository }}
   generate-capsule-provenance:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ gomod:
   proxy: false
 builds:
   - id: "{{ .ProjectName }}"
-    main: ./cmd/
+    main: ./cmd/controller
     binary: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
     env:
       - CGO_ENABLED=0
@@ -23,12 +23,12 @@ builds:
     mod_timestamp: '{{ .CommitTimestamp }}'
     ldflags:
       - >-
-          -X main.Version={{ .Tag }}
-          -X main.GitCommit={{ .Commit }}
-          -X main.GitTag={{ .Tag }}
-          -X main.GitDirty={{ .Date }}
-          -X main.BuildTime={{ .Date }}
-          -X main.GitRepo={{ .ProjectName }}
+        -X github.com/projectcapsule/capsule/internal/version.Version={{ .Tag }}
+        -X github.com/projectcapsule/capsule/internal/version.GitCommit={{ .Commit }}
+        -X github.com/projectcapsule/capsule/internal/version.GitTag={{ .Tag }}
+        -X github.com/projectcapsule/capsule/internal/version.GitDirty={{ .Date }}
+        -X github.com/projectcapsule/capsule/internal/version.BuildTime={{ .Date }}
+        -X github.com/projectcapsule/capsule/internal/version.GitRepo={{ .ProjectName }}
   # - id: "{{ .ProjectName }}-wasm"
   #   main: ./cmd/
   #   binary: "{{ .ProjectName }}.wasm"

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -4,6 +4,6 @@ defaultPlatforms:
 - linux/arm
 builds:
 - id: capsule
-  main: ./cmd/
+  main: ./cmd/controller
   ldflags:
   - '{{ if index .Env "LD_FLAGS" }}{{ .Env.LD_FLAGS }}{{ end }}'

--- a/Makefile
+++ b/Makefile
@@ -369,12 +369,12 @@ ifdef VERSION
 KO_TAGS         := $(KO_TAGS),$(VERSION)
 endif
 
-LD_FLAGS        := "-X main.Version=$(VERSION) \
-					-X main.GitCommit=$(GIT_HEAD_COMMIT) \
-					-X main.GitTag=$(VERSION) \
-					-X main.GitDirty=$(GIT_MODIFIED) \
-					-X main.BuildTime=$(BUILD_DATE) \
-					-X main.GitRepo=$(GIT_REPO)"
+LD_FLAGS        := "-X github.com/projectcapsule/capsule/internal/version.Version=$(VERSION) \
+					-X github.com/projectcapsule/capsule/internal/version.GitCommit=$(GIT_HEAD_COMMIT) \
+					-X github.com/projectcapsule/capsule/internal/version.GitTag=$(VERSION) \
+					-X github.com/projectcapsule/capsule/internal/version.GitDirty=$(GIT_MODIFIED) \
+					-X github.com/projectcapsule/capsule/internal/version.BuildTime=$(BUILD_DATE) \
+					-X github.com/projectcapsule/capsule/internal/version.GitRepo=$(GIT_REPO)"
 
 # Docker Image Build
 # ------------------
@@ -383,7 +383,7 @@ LD_FLAGS        := "-X main.Version=$(VERSION) \
 ko-build-capsule: ko
 	@echo Building Capsule $(KO_TAGS) for $(KO_PLATFORM) >&2
 	@LD_FLAGS=$(LD_FLAGS) KOCACHE=$(KOCACHE) KO_DOCKER_REPO=$(CAPSULE_IMG) \
-		$(KO) build ./cmd/ --bare --tags=$(KO_TAGS) --push=false --local --platform=$(KO_PLATFORM)
+		$(KO) build ./cmd/controller/ --bare --tags=$(KO_TAGS) --push=false --local --platform=$(KO_PLATFORM)
 
 .PHONY: ko-build-all
 ko-build-all: ko-build-capsule
@@ -409,10 +409,15 @@ ko-login: ko
 .PHONY: ko-publish-capsule
 ko-publish-capsule: ko-login ## Build and publish kyvernopre image (with ko)
 	@LD_FLAGS=$(LD_FLAGS) KOCACHE=$(KOCACHE) KO_DOCKER_REPO=$(CAPSULE_IMG) \
-		$(KO) build ./cmd/ --bare --tags=$(KO_TAGS)
+		$(KO) build ./cmd/controller/ --bare --tags=$(KO_TAGS)
 
 .PHONY: ko-publish-all
 ko-publish-all: ko-publish-capsule
+
+# goreleaser
+
+test-release: goreleaser syft
+	PATH=$(LOCALBIN):$${PATH} $(GORELEASER) --skip=publish,sign --snapshot --clean --parallelism 2
 
 # Sorting imports
 .PHONY: goimports
@@ -660,6 +665,20 @@ APIDOCS_GEN_LOOKUP  := fybrik/crdoc
 apidocs-gen: ## Download crdoc locally if necessary.
 	@test -s $(APIDOCS_GEN) && $(APIDOCS_GEN) --version | grep -q $(APIDOCS_GEN_VERSION) || \
 	$(call go-install-tool,$(APIDOCS_GEN),fybrik.io/crdoc@$(APIDOCS_GEN_VERSION))
+
+GORELEASER          := $(LOCALBIN)/goreleaser
+GORELEASER_VERSION  := 2.16.0
+GORELEASER_LOOKUP   := goreleaser/goreleaser
+goreleaser: ## Download goreleaser locally if necessary.
+		test -s $(GORELEASER) && $(GORELEASER) --version | grep -q $(GORELEASER_VERSION) ||  \
+	$(call go-install-tool,$(GORELEASER),github.com/$(GORELEASER_LOOKUP)/v2@v$(GORELEASER_VERSION))
+
+SYFT          := $(LOCALBIN)/syft
+SYFT_VERSION  := 1.45.1
+SYFT_LOOKUP   := anchore/syft
+syft: ## Download syft locally if necessary.
+		test -s $(SYFT) && $(SYFT) --version | grep -q $(SYFT_VERSION) ||  \
+	$(call go-install-tool,$(SYFT),github.com/$(SYFT_LOOKUP)/cmd/syft@v$(SYFT_VERSION))
 
 HARPOON         := $(LOCALBIN)/harpoon
 HARPOON_VERSION := v0.10.2

--- a/api/v1beta2/resourcepool_func_test.go
+++ b/api/v1beta2/resourcepool_func_test.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/projectcapsule/capsule/api/v1beta2"
+	capsulev1beta2 "github.com/projectcapsule/capsule/api/v1beta2"
 	"github.com/projectcapsule/capsule/pkg/api/meta"
 )
 
@@ -21,7 +21,7 @@ func TestGetClaimFromStatus(t *testing.T) {
 	testUID := types.UID("test-uid")
 	otherUID := types.UID("wrong-uid")
 
-	claim := &v1beta2.ResourcePoolClaim{
+	claim := &capsulev1beta2.ResourcePoolClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "claim-a",
 			Namespace: ns,
@@ -29,11 +29,11 @@ func TestGetClaimFromStatus(t *testing.T) {
 		},
 	}
 
-	pool := &v1beta2.ResourcePool{
-		Status: v1beta2.ResourcePoolStatus{
-			Claims: v1beta2.ResourcePoolNamespaceClaimsStatus{
+	pool := &capsulev1beta2.ResourcePool{
+		Status: capsulev1beta2.ResourcePoolStatus{
+			Claims: capsulev1beta2.ResourcePoolNamespaceClaimsStatus{
 				ns: {
-					&v1beta2.ResourcePoolClaimsItem{
+					&capsulev1beta2.ResourcePoolClaimsItem{
 						NamespacedRFC1123ObjectReferenceWithNamespaceWithUID: meta.NamespacedRFC1123ObjectReferenceWithNamespaceWithUID{
 							UID: testUID,
 						},
@@ -77,21 +77,21 @@ func makeResourceList(cpu, memory string) corev1.ResourceList {
 	}
 }
 
-func makeClaim(name, ns string, uid types.UID, res corev1.ResourceList) *v1beta2.ResourcePoolClaim {
-	return &v1beta2.ResourcePoolClaim{
+func makeClaim(name, ns string, uid types.UID, res corev1.ResourceList) *capsulev1beta2.ResourcePoolClaim {
+	return &capsulev1beta2.ResourcePoolClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
 			UID:       uid,
 		},
-		Spec: v1beta2.ResourcePoolClaimSpec{
+		Spec: capsulev1beta2.ResourcePoolClaimSpec{
 			ResourceClaims: res,
 		},
 	}
 }
 
 func TestAssignNamespaces(t *testing.T) {
-	pool := &v1beta2.ResourcePool{}
+	pool := &capsulev1beta2.ResourcePool{}
 
 	namespaces := []corev1.Namespace{
 		{ObjectMeta: metav1.ObjectMeta{Name: "active-ns"}, Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive}},
@@ -105,12 +105,12 @@ func TestAssignNamespaces(t *testing.T) {
 }
 
 func TestAssignClaims(t *testing.T) {
-	pool := &v1beta2.ResourcePool{
-		Status: v1beta2.ResourcePoolStatus{
-			Claims: v1beta2.ResourcePoolNamespaceClaimsStatus{
+	pool := &capsulev1beta2.ResourcePool{
+		Status: capsulev1beta2.ResourcePoolStatus{
+			Claims: capsulev1beta2.ResourcePoolNamespaceClaimsStatus{
 				"ns": {
-					&v1beta2.ResourcePoolClaimsItem{},
-					&v1beta2.ResourcePoolClaimsItem{},
+					&capsulev1beta2.ResourcePoolClaimsItem{},
+					&capsulev1beta2.ResourcePoolClaimsItem{},
 				},
 			},
 		},
@@ -121,7 +121,7 @@ func TestAssignClaims(t *testing.T) {
 }
 
 func TestAddRemoveClaimToStatus(t *testing.T) {
-	pool := &v1beta2.ResourcePool{}
+	pool := &capsulev1beta2.ResourcePool{}
 
 	claim := makeClaim("claim-1", "ns", "uid-1", makeResourceList("1", "1Gi"))
 	pool.AddClaimToStatus(claim)
@@ -136,16 +136,16 @@ func TestAddRemoveClaimToStatus(t *testing.T) {
 }
 
 func TestCalculateResources(t *testing.T) {
-	pool := &v1beta2.ResourcePool{
-		Status: v1beta2.ResourcePoolStatus{
-			Allocation: v1beta2.ResourcePoolQuotaStatus{
+	pool := &capsulev1beta2.ResourcePool{
+		Status: capsulev1beta2.ResourcePoolStatus{
+			Allocation: capsulev1beta2.ResourcePoolQuotaStatus{
 				Hard: corev1.ResourceList{
 					corev1.ResourceLimitsCPU: resource.MustParse("2"),
 				},
 			},
-			Claims: v1beta2.ResourcePoolNamespaceClaimsStatus{
+			Claims: capsulev1beta2.ResourcePoolNamespaceClaimsStatus{
 				"ns": {
-					&v1beta2.ResourcePoolClaimsItem{
+					&capsulev1beta2.ResourcePoolClaimsItem{
 						Claims: corev1.ResourceList{
 							corev1.ResourceLimitsCPU: resource.MustParse("1"),
 						},
@@ -165,9 +165,9 @@ func TestCalculateResources(t *testing.T) {
 }
 
 func TestCanClaimFromPool(t *testing.T) {
-	pool := &v1beta2.ResourcePool{
-		Status: v1beta2.ResourcePoolStatus{
-			Allocation: v1beta2.ResourcePoolQuotaStatus{
+	pool := &capsulev1beta2.ResourcePool{
+		Status: capsulev1beta2.ResourcePoolStatus{
+			Allocation: capsulev1beta2.ResourcePoolQuotaStatus{
 				Hard: corev1.ResourceList{
 					corev1.ResourceLimitsMemory: resource.MustParse("1Gi"),
 				},
@@ -190,16 +190,16 @@ func TestCanClaimFromPool(t *testing.T) {
 }
 
 func TestGetResourceQuotaHardResources(t *testing.T) {
-	pool := &v1beta2.ResourcePool{
-		Spec: v1beta2.ResourcePoolSpec{
+	pool := &capsulev1beta2.ResourcePool{
+		Spec: capsulev1beta2.ResourcePoolSpec{
 			Defaults: corev1.ResourceList{
 				corev1.ResourceLimitsCPU: resource.MustParse("1"),
 			},
 		},
-		Status: v1beta2.ResourcePoolStatus{
-			Claims: v1beta2.ResourcePoolNamespaceClaimsStatus{
+		Status: capsulev1beta2.ResourcePoolStatus{
+			Claims: capsulev1beta2.ResourcePoolNamespaceClaimsStatus{
 				"ns": {
-					&v1beta2.ResourcePoolClaimsItem{
+					&capsulev1beta2.ResourcePoolClaimsItem{
 						Claims: corev1.ResourceList{
 							corev1.ResourceLimitsCPU: resource.MustParse("1"),
 						},
@@ -215,11 +215,11 @@ func TestGetResourceQuotaHardResources(t *testing.T) {
 }
 
 func TestGetNamespaceClaims(t *testing.T) {
-	pool := &v1beta2.ResourcePool{
-		Status: v1beta2.ResourcePoolStatus{
-			Claims: v1beta2.ResourcePoolNamespaceClaimsStatus{
+	pool := &capsulev1beta2.ResourcePool{
+		Status: capsulev1beta2.ResourcePoolStatus{
+			Claims: capsulev1beta2.ResourcePoolNamespaceClaimsStatus{
 				"ns": {
-					&v1beta2.ResourcePoolClaimsItem{
+					&capsulev1beta2.ResourcePoolClaimsItem{
 						NamespacedRFC1123ObjectReferenceWithNamespaceWithUID: meta.NamespacedRFC1123ObjectReferenceWithNamespaceWithUID{UID: "uid1"},
 						Claims: corev1.ResourceList{
 							corev1.ResourceLimitsCPU: resource.MustParse("1"),
@@ -237,11 +237,11 @@ func TestGetNamespaceClaims(t *testing.T) {
 }
 
 func TestGetClaimedByNamespaceClaims(t *testing.T) {
-	pool := &v1beta2.ResourcePool{
-		Status: v1beta2.ResourcePoolStatus{
-			Claims: v1beta2.ResourcePoolNamespaceClaimsStatus{
+	pool := &capsulev1beta2.ResourcePool{
+		Status: capsulev1beta2.ResourcePoolStatus{
+			Claims: capsulev1beta2.ResourcePoolNamespaceClaimsStatus{
 				"ns1": {
-					&v1beta2.ResourcePoolClaimsItem{
+					&capsulev1beta2.ResourcePoolClaimsItem{
 						Claims: makeResourceList("1", "1Gi"),
 					},
 				},
@@ -259,8 +259,8 @@ func TestGetClaimedByNamespaceClaims(t *testing.T) {
 
 func TestIsBoundToResourcePool_2(t *testing.T) {
 	t.Run("bound to resource pool (Assigned=True)", func(t *testing.T) {
-		claim := &v1beta2.ResourcePoolClaim{
-			Status: v1beta2.ResourcePoolClaimStatus{
+		claim := &capsulev1beta2.ResourcePoolClaim{
+			Status: capsulev1beta2.ResourcePoolClaimStatus{
 				Conditions: meta.ConditionList{},
 			},
 		}
@@ -269,8 +269,8 @@ func TestIsBoundToResourcePool_2(t *testing.T) {
 	})
 
 	t.Run("not bound - wrong condition type", func(t *testing.T) {
-		claim := &v1beta2.ResourcePoolClaim{
-			Status: v1beta2.ResourcePoolClaimStatus{
+		claim := &capsulev1beta2.ResourcePoolClaim{
+			Status: capsulev1beta2.ResourcePoolClaimStatus{
 				Conditions: meta.ConditionList{
 					meta.Condition{},
 				},
@@ -285,8 +285,8 @@ func TestIsBoundToResourcePool_2(t *testing.T) {
 	})
 
 	t.Run("not bound - condition not true", func(t *testing.T) {
-		claim := &v1beta2.ResourcePoolClaim{
-			Status: v1beta2.ResourcePoolClaimStatus{
+		claim := &capsulev1beta2.ResourcePoolClaim{
+			Status: capsulev1beta2.ResourcePoolClaimStatus{
 				Conditions: meta.ConditionList{
 					meta.Condition{},
 				},
@@ -301,8 +301,8 @@ func TestIsBoundToResourcePool_2(t *testing.T) {
 	})
 
 	t.Run("not bound - condition not true", func(t *testing.T) {
-		claim := &v1beta2.ResourcePoolClaim{
-			Status: v1beta2.ResourcePoolClaimStatus{
+		claim := &capsulev1beta2.ResourcePoolClaim{
+			Status: capsulev1beta2.ResourcePoolClaimStatus{
 				Conditions: meta.ConditionList{
 					meta.Condition{},
 				},

--- a/api/v1beta2/resourcepoolclaim_func_test.go
+++ b/api/v1beta2/resourcepoolclaim_func_test.go
@@ -9,20 +9,20 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/projectcapsule/capsule/api/v1beta2"
+	capsulev1beta2 "github.com/projectcapsule/capsule/api/v1beta2"
 	"github.com/projectcapsule/capsule/pkg/api/meta"
 )
 
 func TestIsBoundToResourcePool(t *testing.T) {
 	tests := []struct {
 		name     string
-		claim    v1beta2.ResourcePoolClaim
+		claim    capsulev1beta2.ResourcePoolClaim
 		expected bool
 	}{
 		{
 			name: "bound to resource pool (Assigned=True)",
-			claim: v1beta2.ResourcePoolClaim{
-				Status: v1beta2.ResourcePoolClaimStatus{
+			claim: capsulev1beta2.ResourcePoolClaim{
+				Status: capsulev1beta2.ResourcePoolClaimStatus{
 					Condition: metav1.Condition{
 						Type:               meta.BoundCondition,
 						Status:             metav1.ConditionTrue,
@@ -35,8 +35,8 @@ func TestIsBoundToResourcePool(t *testing.T) {
 		},
 		{
 			name: "not bound - wrong condition type",
-			claim: v1beta2.ResourcePoolClaim{
-				Status: v1beta2.ResourcePoolClaimStatus{
+			claim: capsulev1beta2.ResourcePoolClaim{
+				Status: capsulev1beta2.ResourcePoolClaimStatus{
 					Conditions: meta.ConditionList{
 						meta.Condition{
 							Type:               meta.AssignedCondition,
@@ -52,8 +52,8 @@ func TestIsBoundToResourcePool(t *testing.T) {
 		},
 		{
 			name: "not bound - status not true",
-			claim: v1beta2.ResourcePoolClaim{
-				Status: v1beta2.ResourcePoolClaimStatus{
+			claim: capsulev1beta2.ResourcePoolClaim{
+				Status: capsulev1beta2.ResourcePoolClaimStatus{
 					Conditions: meta.ConditionList{
 						meta.Condition{
 							Type:               meta.AssignedCondition,
@@ -69,8 +69,8 @@ func TestIsBoundToResourcePool(t *testing.T) {
 		},
 		{
 			name: "not bound - empty condition",
-			claim: v1beta2.ResourcePoolClaim{
-				Status: v1beta2.ResourcePoolClaimStatus{},
+			claim: capsulev1beta2.ResourcePoolClaim{
+				Status: capsulev1beta2.ResourcePoolClaimStatus{},
 			},
 			expected: false,
 		},
@@ -87,16 +87,16 @@ func TestIsBoundToResourcePool(t *testing.T) {
 func TestGetPool(t *testing.T) {
 	tests := []struct {
 		name     string
-		claim    v1beta2.ResourcePoolClaim
+		claim    capsulev1beta2.ResourcePoolClaim
 		expected string
 	}{
 		{
 			name: "returns status pool name when set",
-			claim: v1beta2.ResourcePoolClaim{
-				Spec: v1beta2.ResourcePoolClaimSpec{
+			claim: capsulev1beta2.ResourcePoolClaim{
+				Spec: capsulev1beta2.ResourcePoolClaimSpec{
 					Pool: "spec-pool",
 				},
-				Status: v1beta2.ResourcePoolClaimStatus{
+				Status: capsulev1beta2.ResourcePoolClaimStatus{
 					Pool: meta.LocalRFC1123ObjectReferenceWithUID{
 						Name: meta.RFC1123Name("status-pool"),
 					},
@@ -106,11 +106,11 @@ func TestGetPool(t *testing.T) {
 		},
 		{
 			name: "falls back to spec pool when status pool name is empty",
-			claim: v1beta2.ResourcePoolClaim{
-				Spec: v1beta2.ResourcePoolClaimSpec{
+			claim: capsulev1beta2.ResourcePoolClaim{
+				Spec: capsulev1beta2.ResourcePoolClaimSpec{
 					Pool: "spec-pool",
 				},
-				Status: v1beta2.ResourcePoolClaimStatus{
+				Status: capsulev1beta2.ResourcePoolClaimStatus{
 					Pool: meta.LocalRFC1123ObjectReferenceWithUID{
 						Name: meta.RFC1123Name(""),
 					},
@@ -120,11 +120,11 @@ func TestGetPool(t *testing.T) {
 		},
 		{
 			name: "falls back to spec pool when status pool struct is zero-value",
-			claim: v1beta2.ResourcePoolClaim{
-				Spec: v1beta2.ResourcePoolClaimSpec{
+			claim: capsulev1beta2.ResourcePoolClaim{
+				Spec: capsulev1beta2.ResourcePoolClaimSpec{
 					Pool: "spec-pool",
 				},
-				Status: v1beta2.ResourcePoolClaimStatus{
+				Status: capsulev1beta2.ResourcePoolClaimStatus{
 					Pool: meta.LocalRFC1123ObjectReferenceWithUID{},
 				},
 			},
@@ -132,11 +132,11 @@ func TestGetPool(t *testing.T) {
 		},
 		{
 			name: "returns empty when both status and spec are empty",
-			claim: v1beta2.ResourcePoolClaim{
-				Spec: v1beta2.ResourcePoolClaimSpec{
+			claim: capsulev1beta2.ResourcePoolClaim{
+				Spec: capsulev1beta2.ResourcePoolClaimSpec{
 					Pool: "",
 				},
-				Status: v1beta2.ResourcePoolClaimStatus{
+				Status: capsulev1beta2.ResourcePoolClaimStatus{
 					Pool: meta.LocalRFC1123ObjectReferenceWithUID{
 						Name: meta.RFC1123Name(""),
 					},
@@ -146,11 +146,11 @@ func TestGetPool(t *testing.T) {
 		},
 		{
 			name: "status wins even if spec differs",
-			claim: v1beta2.ResourcePoolClaim{
-				Spec: v1beta2.ResourcePoolClaimSpec{
+			claim: capsulev1beta2.ResourcePoolClaim{
+				Spec: capsulev1beta2.ResourcePoolClaimSpec{
 					Pool: "spec-pool",
 				},
-				Status: v1beta2.ResourcePoolClaimStatus{
+				Status: capsulev1beta2.ResourcePoolClaimStatus{
 					Pool: meta.LocalRFC1123ObjectReferenceWithUID{
 						Name: meta.RFC1123Name("status-pool"),
 					},

--- a/api/v1beta2/tenant_func_test.go
+++ b/api/v1beta2/tenant_func_test.go
@@ -9,13 +9,13 @@ import (
 
 	rbacv1 "k8s.io/api/rbac/v1"
 
-	"github.com/projectcapsule/capsule/api/v1beta2"
+	capsulev1beta2 "github.com/projectcapsule/capsule/api/v1beta2"
 	capsulerbac "github.com/projectcapsule/capsule/pkg/api/rbac"
 )
 
-func testTenant() *v1beta2.Tenant {
-	return &v1beta2.Tenant{
-		Spec: v1beta2.TenantSpec{
+func testTenant() *capsulev1beta2.Tenant {
+	return &capsulev1beta2.Tenant{
+		Spec: capsulev1beta2.TenantSpec{
 			AdditionalRoleBindings: []capsulerbac.AdditionalRoleBindingsSpec{
 				{
 					ClusterRoleName: "developer",
@@ -39,7 +39,7 @@ func testTenant() *v1beta2.Tenant {
 				},
 			},
 		},
-		Status: v1beta2.TenantStatus{
+		Status: capsulev1beta2.TenantStatus{
 			Owners: capsulerbac.OwnerStatusListSpec{
 				{
 					UserSpec: capsulerbac.UserSpec{
@@ -127,8 +127,8 @@ func TestGetSubjectsByClusterRoles(t *testing.T) {
 func TestGetClusterRolesBySubjectSorted(t *testing.T) {
 	t.Parallel()
 
-	tenant := &v1beta2.Tenant{
-		Spec: v1beta2.TenantSpec{
+	tenant := &capsulev1beta2.Tenant{
+		Spec: capsulev1beta2.TenantSpec{
 			AdditionalRoleBindings: []capsulerbac.AdditionalRoleBindingsSpec{
 				{
 					ClusterRoleName: "deployer",
@@ -150,7 +150,7 @@ func TestGetClusterRolesBySubjectSorted(t *testing.T) {
 				},
 			},
 		},
-		Status: v1beta2.TenantStatus{
+		Status: capsulev1beta2.TenantStatus{
 			Owners: capsulerbac.OwnerStatusListSpec{
 				{
 					UserSpec: capsulerbac.UserSpec{
@@ -229,7 +229,7 @@ func TestGetClusterRolesBySubjectSorted(t *testing.T) {
 	t.Run("empty tenant yields empty slice", func(t *testing.T) {
 		t.Parallel()
 
-		empty := &v1beta2.Tenant{}
+		empty := &capsulev1beta2.Tenant{}
 		got := empty.GetClusterRolesBySubject(nil)
 		if len(got) != 0 {
 			t.Fatalf("expected empty, got %#v", got)

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -57,6 +57,7 @@ import (
 	tlscontroller "github.com/projectcapsule/capsule/internal/controllers/tls"
 	utilscontroller "github.com/projectcapsule/capsule/internal/controllers/utils"
 	"github.com/projectcapsule/capsule/internal/metrics"
+	capsuleversion "github.com/projectcapsule/capsule/internal/version"
 	"github.com/projectcapsule/capsule/internal/webhook"
 	cfgvalidation "github.com/projectcapsule/capsule/internal/webhook/cfg"
 	customquotavalidation "github.com/projectcapsule/capsule/internal/webhook/customquota"
@@ -98,9 +99,9 @@ func init() {
 }
 
 func printVersion() {
-	setupLog.Info(fmt.Sprintf("Capsule Version %s %s%s", GitTag, GitCommit, GitDirty))
-	setupLog.Info(fmt.Sprintf("Build from: %s", GitRepo))
-	setupLog.Info(fmt.Sprintf("Build date: %s", BuildTime))
+	setupLog.Info(fmt.Sprintf("Capsule Version %s %s%s", capsuleversion.GitTag, capsuleversion.GitCommit, capsuleversion.GitDirty))
+	setupLog.Info(fmt.Sprintf("Build from: %s", capsuleversion.GitRepo))
+	setupLog.Info(fmt.Sprintf("Build date: %s", capsuleversion.BuildTime))
 	setupLog.Info(fmt.Sprintf("Go Version: %s", goRuntime.Version()))
 	setupLog.Info(fmt.Sprintf("Go OS/Arch: %s/%s", goRuntime.GOOS, goRuntime.GOARCH))
 }
@@ -634,18 +635,18 @@ func main() {
 				namespacemutation.NamespacePatchGuardHandler(cfg),
 			),
 		),
-		route.ResourcePoolMutation((resourcepool.PoolMutationHandler(ctrl.Log.WithName("webhooks").WithName("resourcepool")))),
-		route.ResourcePoolValidation((resourcepool.PoolValidationHandler(ctrl.Log.WithName("webhooks").WithName("resourcepool")))),
-		route.ResourcePoolClaimMutation((resourcepool.ClaimMutationHandler(ctrl.Log.WithName("webhooks").WithName("resourcepoolclaims")))),
-		route.ResourcePoolClaimValidation((resourcepool.ClaimValidationHandler(ctrl.Log.WithName("webhooks").WithName("resourcepoolclaims")))),
-		route.CustomQuotaValidation((customquotavalidation.CustomQuotaValidationHandler(
+		route.ResourcePoolMutation(resourcepool.PoolMutationHandler(ctrl.Log.WithName("webhooks").WithName("resourcepool"))),
+		route.ResourcePoolValidation(resourcepool.PoolValidationHandler(ctrl.Log.WithName("webhooks").WithName("resourcepool"))),
+		route.ResourcePoolClaimMutation(resourcepool.ClaimMutationHandler(ctrl.Log.WithName("webhooks").WithName("resourcepoolclaims"))),
+		route.ResourcePoolClaimValidation(resourcepool.ClaimValidationHandler(ctrl.Log.WithName("webhooks").WithName("resourcepoolclaims"))),
+		route.CustomQuotaValidation(customquotavalidation.CustomQuotaValidationHandler(
 			targetsCache,
 			jsonPathCache,
-		))),
-		route.GlobalCustomQuotaValidation((customquotavalidation.GlobalCustomQuotaValidationHandler(
+		)),
+		route.GlobalCustomQuotaValidation(customquotavalidation.GlobalCustomQuotaValidationHandler(
 			targetsCache,
 			jsonPathCache,
-		))),
+		)),
 		route.CalculationCustomQuotas(
 			customquotavalidation.ObjectCalculationHandler(
 				targetsCache,

--- a/e2e/tenantowner_status_test.go
+++ b/e2e/tenantowner_status_test.go
@@ -1,5 +1,6 @@
 // Copyright 2020-2026 Project Capsule Authors
 // SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (

--- a/internal/controllers/tenantowner/enqueue.go
+++ b/internal/controllers/tenantowner/enqueue.go
@@ -1,5 +1,6 @@
 // Copyright 2020-2026 Project Capsule Authors
 // SPDX-License-Identifier: Apache-2.0
+
 package tenantowners
 
 import (

--- a/internal/controllers/tenantowner/manager.go
+++ b/internal/controllers/tenantowner/manager.go
@@ -1,5 +1,6 @@
 // Copyright 2020-2026 Project Capsule Authors
 // SPDX-License-Identifier: Apache-2.0
+
 package tenantowners
 
 import (

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,7 +1,7 @@
 // Copyright 2020-2026 Project Capsule Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package main
+package version
 
 // GitRepo ...
 var GitRepo = ""

--- a/internal/webhook/customquota/calculation.go
+++ b/internal/webhook/customquota/calculation.go
@@ -1,5 +1,6 @@
 // Copyright 2020-2026 Project Capsule Authors
 // SPDX-License-Identifier: Apache-2.0
+
 package customquota
 
 import (

--- a/internal/webhook/customquota/customquota_validating.go
+++ b/internal/webhook/customquota/customquota_validating.go
@@ -1,5 +1,6 @@
 // Copyright 2020-2026 Project Capsule Authors
 // SPDX-License-Identifier: Apache-2.0
+
 package customquota
 
 import (

--- a/internal/webhook/customquota/globalcustomquota_validating.go
+++ b/internal/webhook/customquota/globalcustomquota_validating.go
@@ -1,5 +1,6 @@
 // Copyright 2020-2026 Project Capsule Authors
 // SPDX-License-Identifier: Apache-2.0
+
 package customquota
 
 import (

--- a/internal/webhook/customquota/utils.go
+++ b/internal/webhook/customquota/utils.go
@@ -1,5 +1,6 @@
 // Copyright 2020-2026 Project Capsule Authors
 // SPDX-License-Identifier: Apache-2.0
+
 package customquota
 
 import (

--- a/pkg/runtime/admission/utils.go
+++ b/pkg/runtime/admission/utils.go
@@ -1,5 +1,6 @@
 // Copyright 2020-2026 Project Capsule Authors
 // SPDX-License-Identifier: Apache-2.0
+
 package admission
 
 import (

--- a/pkg/runtime/handlers/handlers.go
+++ b/pkg/runtime/handlers/handlers.go
@@ -22,7 +22,7 @@ type Handler interface {
 	OnUpdate(client client.Client, reader client.Reader, decoder admission.Decoder, recorder events.EventRecorder) Func
 }
 
-type HanderWithTenant interface {
+type HandlerWithTenant interface {
 	OnCreate(c client.Client, reader client.Reader, decoder admission.Decoder, recorder events.EventRecorder, tnt *capsulev1beta2.Tenant) Func
 	OnUpdate(c client.Client, reader client.Reader, decoder admission.Decoder, recorder events.EventRecorder, tnt *capsulev1beta2.Tenant) Func
 	OnDelete(c client.Client, reader client.Reader, decoder admission.Decoder, recorder events.EventRecorder, tnt *capsulev1beta2.Tenant) Func

--- a/pkg/template/functions/age.go
+++ b/pkg/template/functions/age.go
@@ -1,5 +1,6 @@
 // Copyright 2020-2026 Project Capsule Authors
 // SPDX-License-Identifier: Apache-2.0
+
 package functions
 
 import (

--- a/pkg/template/functions/conversion.go
+++ b/pkg/template/functions/conversion.go
@@ -1,5 +1,6 @@
 // Copyright 2020-2026 Project Capsule Authors
 // SPDX-License-Identifier: Apache-2.0
+
 package functions
 
 import (

--- a/pkg/template/functions/funcmap.go
+++ b/pkg/template/functions/funcmap.go
@@ -1,5 +1,6 @@
 // Copyright 2020-2026 Project Capsule Authors
 // SPDX-License-Identifier: Apache-2.0
+
 package functions
 
 import (

--- a/pkg/template/functions/uuid.go
+++ b/pkg/template/functions/uuid.go
@@ -1,5 +1,6 @@
 // Copyright 2020-2026 Project Capsule Authors
 // SPDX-License-Identifier: Apache-2.0
+
 package functions
 
 import (

--- a/pkg/template/reference.go
+++ b/pkg/template/reference.go
@@ -1,5 +1,6 @@
 // Copyright 2020-2026 Project Capsule Authors
 // SPDX-License-Identifier: Apache-2.0
+
 package template
 
 import (

--- a/pkg/utils/node_selector_test.go
+++ b/pkg/utils/node_selector_test.go
@@ -1,5 +1,6 @@
 // Copyright 2020-2026 Project Capsule Authors
 // SPDX-License-Identifier: Apache-2.0
+
 package utils_test
 
 import (

--- a/pkg/utils/tenant_labels.go
+++ b/pkg/utils/tenant_labels.go
@@ -12,15 +12,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/projectcapsule/capsule/api/v1beta1"
-	"github.com/projectcapsule/capsule/api/v1beta2"
+	capsulev1beta2 "github.com/projectcapsule/capsule/api/v1beta2"
 	"github.com/projectcapsule/capsule/pkg/api/meta"
 )
 
 func GetTypeLabel(t runtime.Object) (label string, err error) {
 	switch v := t.(type) {
-	case *v1beta1.Tenant, *v1beta2.Tenant:
+	case *v1beta1.Tenant, *capsulev1beta2.Tenant:
 		return meta.TenantLabel, nil
-	case *v1beta2.ResourcePool:
+	case *capsulev1beta2.ResourcePool:
 		return meta.ResourcePoolLabel, nil
 	case *corev1.LimitRange:
 		return meta.LimitRangeLabel, nil


### PR DESCRIPTION
Moves the controller main.go into the module path cmd/controller.
This is in preparation for #1959 where an traditional cli binary is introduced.

Minor formatting issues are also addressed and a make task added to run roreleaser local. `make test-release`
