### PR TITLE
fix(webhook): remove dead diff code block that panics on nil namespace metadata

### DIFF
--- a/internal/webhook/namespace/validation/user_metadata.go
+++ b/internal/webhook/namespace/validation/user_metadata.go
@@ -111,39 +111,6 @@ func (h *userMetadataHandler) OnUpdate(
 			}
 		}
 
-		labels := maps.Clone(oldNs.GetLabels())
-		annotations := maps.Clone(oldNs.GetAnnotations())
-
-		for key, value := range newNs.GetLabels() {
-			v, ok := labels[key]
-			if !ok {
-				labels[key] = value
-
-				continue
-			}
-
-			if v != value {
-				continue
-			}
-
-			delete(labels, key)
-		}
-
-		for key, value := range newNs.GetAnnotations() {
-			v, ok := annotations[key]
-			if !ok {
-				annotations[key] = value
-
-				continue
-			}
-
-			if v != value {
-				continue
-			}
-
-			delete(annotations, key)
-		}
-
 		if tnt.Spec.NamespaceOptions != nil {
 			labels, annotations, err := userMetadataForValidation(newNs, oldNs, tnt)
 			if err != nil {


### PR DESCRIPTION
In userMetadataHandler.OnUpdate the per-request labels/annotations diff is computed twice. The inline block at the top clones oldNs metadata and diffs it against newNs, but its results are immediately shadowed by the `labels, annotations, err := userMetadataForValidation(...)` declaration in the `tnt.Spec.NamespaceOptions != nil` branch, which recomputes the same diff (via metadataForValidation) and is the only version actually passed to validateUserMetadata. The inline block is therefore dead code.

It is also a  panic: `maps.Clone(oldNs.GetAnnotations())` returns nil for a namespace with no annotations, and the following `annotations[key] = value` then panics with "assignment to entry in nil map" (same with labels). 
This happens when using features like NamespaceOptions.AdditionalMetadataList on a namespace that had none.

The dead block and panic was introduced in a6927c5 (#1947).

<!--
Read the contribution guidelines before creating a pull request.

https://github.com/projectcapsule/capsule/blob/main/CONTRIBUTING.md

Thanks for spending some time for improving and fixing Capsule!
-->
