### PR TITLE
fix(globalcustomqota): object was not added to quota when namespace was not reconciled

### DIFF
--- a/internal/webhook/customquota/calculation.go
+++ b/internal/webhook/customquota/calculation.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -697,11 +698,44 @@ func (h *objectCalculationHandler) matchGlobalCustomQuotas(
 
 	objLabels := labels.Set(u.GetLabels())
 
+	// Fetch the namespace once so that per-GCQ namespace-selector
+	// checks below are a pure in-memory label
+	// evaluation rather than a repeated cache lookup.
+	var nsLabels labels.Set
+
+	if req.Namespace != "" {
+		ns := &corev1.Namespace{}
+		if err := c.Get(ctx, types.NamespacedName{Name: req.Namespace}, ns); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, nil
+			}
+
+			return nil, fmt.Errorf("get namespace %s: %w", req.Namespace, err)
+		}
+
+		nsLabels = labels.Set(ns.GetLabels())
+	}
+
 	out := make([]quota.MatchedQuota, 0)
 
 	for _, gcq := range list.Items {
-		if !gcq.Status.NamespacePresent("*") && !gcq.Status.NamespacePresent(req.Namespace) {
-			continue
+		// Evaluate namespace selectors directly from Spec against the live
+		// namespace labels (informer-cached) rather than checking
+		// Status.Namespaces, which is only updated after a controller reconcile.
+		// This closes the window where newly-labelled namespaces bypass the quota
+		// before the controller has had a chance to reconcile.
+		if len(gcq.Spec.NamespaceSelectors) > 0 {
+			nsLabelSelectors := make([]metav1.LabelSelector, 0, len(gcq.Spec.NamespaceSelectors))
+
+			for _, nsSel := range gcq.Spec.NamespaceSelectors {
+				if nsSel.LabelSelector != nil {
+					nsLabelSelectors = append(nsLabelSelectors, *nsSel.LabelSelector)
+				}
+			}
+
+			if !selectors.MatchesSelectors(nsLabels, nsLabelSelectors) {
+				continue
+			}
 		}
 
 		if !selectors.MatchesSelectors(objLabels, gcq.Spec.ScopeSelectors) {

--- a/pkg/runtime/indexers/customquota/customquota_test.go
+++ b/pkg/runtime/indexers/customquota/customquota_test.go
@@ -9,6 +9,7 @@ import (
 
 	capsulev1beta2 "github.com/projectcapsule/capsule/api/v1beta2"
 	"github.com/projectcapsule/capsule/pkg/api/meta"
+	capruntime "github.com/projectcapsule/capsule/pkg/api/runtime"
 	"github.com/projectcapsule/capsule/pkg/runtime/indexers/customquota"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -19,6 +20,9 @@ func TestCustomQuotaIndexers(t *testing.T) {
 
 	target := capsulev1beta2.CustomQuotaStatusTarget{
 		GroupVersionKind: metav1.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+	}
+	globalSource := capsulev1beta2.CustomQuotaSpecSource{
+		VersionKind: capruntime.VersionKind{APIVersion: "apps/v1", Kind: "Deployment"},
 	}
 	claim := capsulev1beta2.CustomQuotaClaimItem{
 		NamespacedObjectWithUIDReference: meta.NamespacedObjectWithUIDReference{UID: types.UID("claim-uid")},
@@ -50,8 +54,10 @@ func TestCustomQuotaIndexers(t *testing.T) {
 			name:  "global target",
 			field: customquota.GlobalTargetReference{}.Field(),
 			got: customquota.GlobalTargetReference{}.Func()(&capsulev1beta2.GlobalCustomQuota{
-				Status: capsulev1beta2.GlobalCustomQuotaStatus{
-					CustomQuotaStatus: capsulev1beta2.CustomQuotaStatus{Targets: []capsulev1beta2.CustomQuotaStatusTarget{target}},
+				Spec: capsulev1beta2.GlobalCustomQuotaSpec{
+					CustomQuotaSpec: capsulev1beta2.CustomQuotaSpec{
+						Sources: []capsulev1beta2.CustomQuotaSpecSource{globalSource},
+					},
 				},
 			}),
 			want: []string{target.String()},

--- a/pkg/runtime/indexers/customquota/global_target.go
+++ b/pkg/runtime/indexers/customquota/global_target.go
@@ -4,6 +4,7 @@
 package customquota
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	capsulev1beta2 "github.com/projectcapsule/capsule/api/v1beta2"
@@ -23,10 +24,18 @@ func (o GlobalTargetReference) Func() client.IndexerFunc {
 	return func(object client.Object) []string {
 		tr := object.(*capsulev1beta2.GlobalCustomQuota) //nolint:forcetypeassert
 
-		targets := make([]string, 0, len(tr.Status.Targets))
+		// Index on Spec.Sources (declared intent) rather than Status.Targets
+		// (reconciled state) so the webhook can match quotas immediately after
+		// creation, before the controller has had a chance to reconcile.
+		targets := make([]string, 0, len(tr.Spec.Sources))
 
-		for _, t := range tr.Status.Targets {
-			targets = append(targets, t.String())
+		for _, src := range tr.Spec.Sources {
+			gvk := src.GroupVersionKind()
+			targets = append(targets, metav1.GroupVersionKind{
+				Group:   gvk.Group,
+				Version: gvk.Version,
+				Kind:    gvk.Kind,
+			}.String())
 		}
 
 		return targets


### PR DESCRIPTION
When a namespace is created and not yet fully reconciled, a object (pod for example) can slip through the quota since the statusses aren't there yet. With this fix, there will be a lookup to the .metadata instead of the .status. 