### PR TITLE
fix(webhook): let administrators repair namespaces with an inconsistent tenant reference

### DIFF
--- a/e2e/config_administrators_test.go
+++ b/e2e/config_administrators_test.go
@@ -284,4 +284,139 @@ var _ = Describe("Administrators", Ordered, Label("namespace", "permissions", "a
 		})
 
 	})
+
+	It("repairing namespaces with an inconsistent tenant reference as administrator", func() {
+		ctx := context.TODO()
+
+		ns1 := NewNamespace("", map[string]string{
+			meta.TenantLabel: tnt1.GetName(),
+		})
+
+		By("creating a namespace assigned to the tenant", func() {
+			NamespaceCreation(ns1, admin, defaultTimeoutInterval).Should(Succeed())
+			NamespaceIsPartOfTenant(tnt1, ns1).Should(Succeed())
+		})
+
+		By("stripping the Tenant ownerReference as administrator (simulates the leftover of a webhook outage)", func() {
+			Eventually(func() error {
+				current := NewNamespace(ns1.Name)
+
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: ns1.Name}, current); err != nil {
+					return err
+				}
+
+				original := current.DeepCopy()
+				current.OwnerReferences = nil
+
+				return impersonationClient(admin.Name, nil).Patch(ctx, current, client.MergeFrom(original))
+			}, defaultTimeoutInterval, defaultPollInterval).Should(Succeed())
+		})
+
+		By("verifying the namespace is inconsistent (tenant label without Tenant ownerReference)", func() {
+			current := NewNamespace(ns1.Name)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ns1.Name}, current)).To(Succeed())
+			Expect(current.Labels[meta.TenantLabel]).To(Equal(tnt1.GetName()))
+			Expect(current.OwnerReferences).To(BeEmpty())
+		})
+
+		By("updating the inconsistent namespace as tenant owner is still denied", func() {
+			current := NewNamespace(ns1.Name)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ns1.Name}, current)).To(Succeed())
+
+			original := current.DeepCopy()
+			if current.Annotations == nil {
+				current.Annotations = map[string]string{}
+			}
+
+			current.Annotations["e2e.capsule.clastix.io/owner-update"] = "true"
+
+			err := impersonationClient(tnt1.Spec.Owners[0].Name, nil).Patch(ctx, current, client.MergeFrom(original))
+			Expect(err).To(HaveOccurred())
+		})
+
+		By("updating the inconsistent namespace as administrator succeeds", func() {
+			Eventually(func() error {
+				current := NewNamespace(ns1.Name)
+
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: ns1.Name}, current); err != nil {
+					return err
+				}
+
+				original := current.DeepCopy()
+				if current.Annotations == nil {
+					current.Annotations = map[string]string{}
+				}
+
+				current.Annotations["e2e.capsule.clastix.io/admin-inconsistent-update"] = "true"
+
+				return impersonationClient(admin.Name, nil).Patch(ctx, current, client.MergeFrom(original))
+			}, defaultTimeoutInterval, defaultPollInterval).Should(Succeed())
+		})
+
+		By("repairing the namespace by restoring the Tenant ownerReference as administrator", func() {
+			Eventually(func() error {
+				tnt := &capsulev1beta2.Tenant{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: tnt1.GetName()}, tnt); err != nil {
+					return err
+				}
+
+				current := NewNamespace(ns1.Name)
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: ns1.Name}, current); err != nil {
+					return err
+				}
+
+				original := current.DeepCopy()
+				current.OwnerReferences = []metav1.OwnerReference{
+					{
+						APIVersion: capsulev1beta2.GroupVersion.String(),
+						Kind:       "Tenant",
+						Name:       tnt.GetName(),
+						UID:        tnt.GetUID(),
+					},
+				}
+
+				return impersonationClient(admin.Name, nil).Patch(ctx, current, client.MergeFrom(original))
+			}, defaultTimeoutInterval, defaultPollInterval).Should(Succeed())
+
+			NamespaceIsPartOfTenant(tnt1, ns1).Should(Succeed())
+		})
+
+		ns2 := NewNamespace("", map[string]string{
+			meta.TenantLabel: tnt1.GetName(),
+		})
+
+		By("creating a second namespace assigned to the tenant and making it inconsistent", func() {
+			NamespaceCreation(ns2, admin, defaultTimeoutInterval).Should(Succeed())
+			NamespaceIsPartOfTenant(tnt1, ns2).Should(Succeed())
+
+			Eventually(func() error {
+				current := NewNamespace(ns2.Name)
+
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: ns2.Name}, current); err != nil {
+					return err
+				}
+
+				original := current.DeepCopy()
+				current.OwnerReferences = nil
+
+				return impersonationClient(admin.Name, nil).Patch(ctx, current, client.MergeFrom(original))
+			}, defaultTimeoutInterval, defaultPollInterval).Should(Succeed())
+		})
+
+		By("deleting the inconsistent namespace as administrator succeeds", func() {
+			Eventually(func() error {
+				current := NewNamespace(ns2.Name)
+
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: ns2.Name}, current); err != nil {
+					return err
+				}
+
+				return impersonationClient(admin.Name, nil).Delete(ctx, current)
+			}, defaultTimeoutInterval, defaultPollInterval).Should(Succeed())
+		})
+
+		By("deleting namespace", func() {
+			Expect(k8sClient.Delete(ctx, ns1)).Should(Succeed())
+		})
+	})
 })

--- a/e2e/config_administrators_test.go
+++ b/e2e/config_administrators_test.go
@@ -332,6 +332,9 @@ var _ = Describe("Administrators", Ordered, Label("namespace", "permissions", "a
 
 			err := impersonationClient(tnt1.Spec.Owners[0].Name, nil).Patch(ctx, current, client.MergeFrom(original))
 			Expect(err).To(HaveOccurred())
+			// The denial must come from the webhook detecting the inconsistent
+			// tenant reference, not from something unrelated (e.g. RBAC).
+			Expect(err.Error()).To(ContainSubstring("no Tenant ownerReference"))
 		})
 
 		By("updating the inconsistent namespace as administrator succeeds", func() {
@@ -379,6 +382,17 @@ var _ = Describe("Administrators", Ordered, Label("namespace", "permissions", "a
 			}, defaultTimeoutInterval, defaultPollInterval).Should(Succeed())
 
 			NamespaceIsPartOfTenant(tnt1, ns1).Should(Succeed())
+
+			// Verify the repair outcome directly on the namespace: the Tenant
+			// ownerReference is restored and consistent with the tenant label.
+			Eventually(func(g Gomega) {
+				current := NewNamespace(ns1.Name)
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ns1.Name}, current)).To(Succeed())
+				g.Expect(current.Labels[meta.TenantLabel]).To(Equal(tnt1.GetName()))
+				g.Expect(current.OwnerReferences).To(HaveLen(1))
+				g.Expect(current.OwnerReferences[0].Kind).To(Equal("Tenant"))
+				g.Expect(current.OwnerReferences[0].Name).To(Equal(tnt1.GetName()))
+			}, defaultTimeoutInterval, defaultPollInterval).Should(Succeed())
 		})
 
 		ns2 := NewNamespace("", map[string]string{

--- a/internal/webhook/namespace/validation/handler.go
+++ b/internal/webhook/namespace/validation/handler.go
@@ -5,6 +5,7 @@ package validation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -101,7 +102,9 @@ func (h *handler) OnDelete(
 			// Administrators must be able to delete namespaces carrying an
 			// inconsistent tenant reference (they could otherwise never get
 			// rid of them): treat such namespaces as tenant-less for them.
-			if !user.IsAdmin() {
+			// Transient API errors while resolving the Tenant still fail
+			// closed for everybody.
+			if !user.IsAdmin() || !errors.Is(err, tenant.ErrInconsistentTenantReference) {
 				return ad.ErroredResponse(err)
 			}
 
@@ -155,19 +158,20 @@ func (h *handler) OnUpdate(
 			}
 		}
 
-		// Resolution errors (an inconsistent tenant reference, e.g. a tenant
-		// label without the matching Tenant ownerReference, as left behind by
-		// a webhook outage) are only fatal for non-administrators: admins may
-		// repair such namespaces — including the update that restores the
-		// missing ownerReference — the affected object being treated as
-		// tenant-less until consistent again.
+		// Inconsistent tenant references (e.g. a tenant label without the
+		// matching Tenant ownerReference, as left behind by a webhook outage)
+		// are only fatal for non-administrators: admins may repair such
+		// namespaces — including the update that restores the missing
+		// ownerReference — the affected object being treated as tenant-less
+		// until consistent again. Transient API errors while resolving the
+		// Tenant still fail closed for everybody.
 		oldTenant, oldErr := tenant.ResolveNamespaceTenant(ctx, reader, oldNs)
-		if oldErr != nil && !user.IsAdmin() {
+		if oldErr != nil && (!user.IsAdmin() || !errors.Is(oldErr, tenant.ErrInconsistentTenantReference)) {
 			return ad.ErroredResponse(oldErr)
 		}
 
 		newTenant, newErr := tenant.ResolveNamespaceTenant(ctx, reader, ns)
-		if newErr != nil && !user.IsAdmin() {
+		if newErr != nil && (!user.IsAdmin() || !errors.Is(newErr, tenant.ErrInconsistentTenantReference)) {
 			return ad.ErroredResponse(newErr)
 		}
 

--- a/internal/webhook/namespace/validation/handler.go
+++ b/internal/webhook/namespace/validation/handler.go
@@ -98,7 +98,14 @@ func (h *handler) OnDelete(
 
 		tnt, err := tenant.ResolveNamespaceTenant(ctx, reader, oldNs)
 		if err != nil {
-			return ad.ErroredResponse(err)
+			// Administrators must be able to delete namespaces carrying an
+			// inconsistent tenant reference (they could otherwise never get
+			// rid of them): treat such namespaces as tenant-less for them.
+			if !user.IsAdmin() {
+				return ad.ErroredResponse(err)
+			}
+
+			tnt = nil
 		}
 
 		if tnt == nil {
@@ -148,14 +155,20 @@ func (h *handler) OnUpdate(
 			}
 		}
 
-		oldTenant, err := tenant.ResolveNamespaceTenant(ctx, reader, oldNs)
-		if err != nil {
-			return ad.ErroredResponse(err)
+		// Resolution errors (an inconsistent tenant reference, e.g. a tenant
+		// label without the matching Tenant ownerReference, as left behind by
+		// a webhook outage) are only fatal for non-administrators: admins may
+		// repair such namespaces — including the update that restores the
+		// missing ownerReference — the affected object being treated as
+		// tenant-less until consistent again.
+		oldTenant, oldErr := tenant.ResolveNamespaceTenant(ctx, reader, oldNs)
+		if oldErr != nil && !user.IsAdmin() {
+			return ad.ErroredResponse(oldErr)
 		}
 
-		newTenant, err := tenant.ResolveNamespaceTenant(ctx, reader, ns)
-		if err != nil {
-			return ad.ErroredResponse(err)
+		newTenant, newErr := tenant.ResolveNamespaceTenant(ctx, reader, ns)
+		if newErr != nil && !user.IsAdmin() {
+			return ad.ErroredResponse(newErr)
 		}
 
 		if !user.IsAdmin() {

--- a/pkg/tenant/namespaces.go
+++ b/pkg/tenant/namespaces.go
@@ -25,6 +25,13 @@ import (
 	"github.com/projectcapsule/capsule/pkg/api/meta"
 )
 
+// ErrInconsistentTenantReference marks the *semantic* namespace↔tenant
+// reference inconsistencies detected by ResolveNamespaceTenant (tenant label
+// without Tenant ownerReference and the other mismatch states), as opposed to
+// transient API errors while resolving the Tenant. Callers can rely on
+// errors.Is to distinguish a repairable inconsistency from a lookup failure.
+var ErrInconsistentTenantReference = errors.New("inconsistent tenant reference")
+
 type NamespacedResourceCache interface {
 	Get(disco discovery.DiscoveryInterface) ([]schema.GroupVersionResource, error)
 }
@@ -244,13 +251,13 @@ func ResolveNamespaceTenant(
 		return nil, nil
 
 	case len(refs) > 1:
-		return nil, fmt.Errorf("namespace can not have multiple Tenant ownerReferences")
+		return nil, fmt.Errorf("%w: namespace can not have multiple Tenant ownerReferences", ErrInconsistentTenantReference)
 
 	case label == "" && len(refs) == 1:
-		return nil, fmt.Errorf("namespace has Tenant ownerReference %q but no tenant label", refs[0].Name)
+		return nil, fmt.Errorf("%w: namespace has Tenant ownerReference %q but no tenant label", ErrInconsistentTenantReference, refs[0].Name)
 
 	case label != "" && len(refs) == 0:
-		return nil, fmt.Errorf("namespace has tenant label %q but no Tenant ownerReference", label)
+		return nil, fmt.Errorf("%w: namespace has tenant label %q but no Tenant ownerReference", ErrInconsistentTenantReference, label)
 	}
 
 	tnt, err := GetTenantByOwnerreferences(ctx, reader, refs)
@@ -259,11 +266,11 @@ func ResolveNamespaceTenant(
 	}
 
 	if tnt == nil {
-		return nil, fmt.Errorf("namespace references unknown Tenant %q", refs[0].Name)
+		return nil, fmt.Errorf("%w: namespace references unknown Tenant %q", ErrInconsistentTenantReference, refs[0].Name)
 	}
 
 	if tnt.GetName() != label {
-		return nil, fmt.Errorf("namespace label %q does not match owner reference %q", label, tnt.GetName())
+		return nil, fmt.Errorf("%w: namespace label %q does not match owner reference %q", ErrInconsistentTenantReference, label, tnt.GetName())
 	}
 
 	return tnt, nil


### PR DESCRIPTION
## Summary

Fixes #2022.

A namespace carrying the tenant label without the matching `Tenant` ownerReference (the typical leftover of a webhook outage) could neither be updated nor deleted by anybody: in the namespace **validation** handler, `ResolveNamespaceTenant()` errors were turned into denials *before* the `administrators` bypass could apply — locking out even the identities that `CapsuleConfiguration.spec.administrators` is meant to empower, so the inconsistency could never be repaired through the API.

## Changes

- `internal/webhook/namespace/validation/handler.go`:
  - **OnUpdate**: resolution errors on the old/new object are only fatal for non-administrators. Administrators see the inconsistent object as tenant-less, which allows the repair itself (restoring the missing ownerReference, or removing the stale label) while every non-admin check is preserved unchanged.
  - **OnDelete**: same tolerance, so administrators can also get rid of an inconsistent namespace.
  - **OnCreate is intentionally unchanged**: on that path the mutating assignment webhook guarantees consistency, and the existing e2e (`creating namespace with faulty label`) expects strictness.
- `e2e/config_administrators_test.go`: new case *"repairing namespaces with an inconsistent tenant reference as administrator"* — makes a namespace inconsistent, asserts a tenant owner is still denied, asserts an administrator can update it, repair it (ownerReference restored → namespace back in the tenant), and delete a second inconsistent one.

## Behaviour matrix (update/delete of an inconsistent namespace)

| Identity | Before | After |
|---|---|---|
| tenant owner / capsule user | denied (error) | denied (unchanged) |
| administrator | **denied (error)** | **allowed — treated as tenant-less, repair possible** |

This mirrors the mutating `guard` handler, which already fully bypasses administrators, and follows up on #1941 (admin updates of tenant-*less* namespaces).
