### PR TITLE
fix: clamp ResourcePool available at zero and stop corrupting Hard

### DIFF
--- a/api/v1beta2/resourcepool_func.go
+++ b/api/v1beta2/resourcepool_func.go
@@ -159,12 +159,22 @@ func (r *ResourcePool) CalculateAvailableResources() {
 	available := corev1.ResourceList{}
 
 	for res, qt := range r.Status.Allocation.Hard {
+		// Copy qt before subtracting: ranging over the map yields live
+		// references, so mutating it in place would corrupt Hard.
+		remaining := qt.DeepCopy()
+
 		amount, exists := r.Status.Allocation.Claimed[res]
 		if exists {
-			qt.Sub(amount)
+			remaining.Sub(amount)
 		}
 
-		available[res] = qt
+		// A pool can never offer a negative amount of resources, so clamp
+		// at zero. This also keeps Hard intact for downstream math.
+		if remaining.Sign() < 0 {
+			remaining = resource.MustParse("0")
+		}
+
+		available[res] = remaining
 	}
 
 	r.Status.Allocation.Available = available

--- a/api/v1beta2/resourcepool_func.go
+++ b/api/v1beta2/resourcepool_func.go
@@ -206,6 +206,13 @@ func (r *ResourcePool) GetAvailableClaimableResources() corev1.ResourceList {
 
 		qt.Sub(claimed)
 
+		// A pool can never offer a negative amount of resources, so clamp at
+		// zero here too, otherwise callers that build PoolExhausted messages
+		// from this value can surface negative available quantities.
+		if qt.Sign() < 0 {
+			qt = resource.MustParse("0")
+		}
+
 		hard[resourceName] = qt
 	}
 

--- a/api/v1beta2/resourcepool_func.go
+++ b/api/v1beta2/resourcepool_func.go
@@ -159,9 +159,9 @@ func (r *ResourcePool) CalculateAvailableResources() {
 	available := corev1.ResourceList{}
 
 	for res, qt := range r.Status.Allocation.Hard {
-		// Copy qt before subtracting: ranging over the map yields live
-		// references, so mutating it in place would corrupt Hard.
-		remaining := qt.DeepCopy()
+		// Deep-copy qt before subtracting: resource.Quantity contains internal pointers,
+		// so a shallow copy can alias the map entry and Sub() could mutate Hard.
+		// Using DeepCopy() ensures Hard remains unchanged.
 
 		amount, exists := r.Status.Allocation.Claimed[res]
 		if exists {

--- a/api/v1beta2/resourcepool_func.go
+++ b/api/v1beta2/resourcepool_func.go
@@ -162,6 +162,7 @@ func (r *ResourcePool) CalculateAvailableResources() {
 		// Deep-copy qt before subtracting: resource.Quantity contains internal pointers,
 		// so a shallow copy can alias the map entry and Sub() could mutate Hard.
 		// Using DeepCopy() ensures Hard remains unchanged.
+		remaining := qt.DeepCopy()
 
 		amount, exists := r.Status.Allocation.Claimed[res]
 		if exists {

--- a/api/v1beta2/resourcepool_func_test.go
+++ b/api/v1beta2/resourcepool_func_test.go
@@ -355,3 +355,26 @@ func TestIsBoundToResourcePool_2(t *testing.T) {
 	})
 
 }
+
+func TestGetAvailableClaimableResources_OverSubscriptionDoesNotGoNegative(t *testing.T) {
+	pool := &capsulev1beta2.ResourcePool{
+		Status: capsulev1beta2.ResourcePoolStatus{
+			Allocation: capsulev1beta2.ResourcePoolQuotaStatus{
+				Hard: corev1.ResourceList{
+					corev1.ResourceLimitsCPU: resource.MustParse("10"),
+				},
+				Claimed: corev1.ResourceList{
+					corev1.ResourceLimitsCPU: resource.MustParse("55"),
+				},
+			},
+		},
+	}
+
+	// Claimed exceeds Hard, so Hard-Claimed is negative. The helper must clamp
+	// at zero so negative available values never leak into PoolExhausted
+	// condition messages.
+	claimable := pool.GetAvailableClaimableResources()
+	got := claimable[corev1.ResourceLimitsCPU]
+	assert.Equal(t, 0, (&got).Cmp(resource.MustParse("0")))
+	assert.False(t, (&got).Sign() < 0)
+}

--- a/api/v1beta2/resourcepool_func_test.go
+++ b/api/v1beta2/resourcepool_func_test.go
@@ -164,6 +164,44 @@ func TestCalculateResources(t *testing.T) {
 	assert.Equal(t, 0, (&actualAvailable).Cmp(resource.MustParse("1")))
 }
 
+func TestCalculateResources_OverSubscriptionDoesNotGoNegative(t *testing.T) {
+	pool := &capsulev1beta2.ResourcePool{
+		Status: capsulev1beta2.ResourcePoolStatus{
+			Allocation: capsulev1beta2.ResourcePoolQuotaStatus{
+				Hard: corev1.ResourceList{
+					corev1.ResourceLimitsCPU: resource.MustParse("10"),
+				},
+			},
+			Claims: capsulev1beta2.ResourcePoolNamespaceClaimsStatus{
+				"ns": {
+					&capsulev1beta2.ResourcePoolClaimsItem{
+						Claims: corev1.ResourceList{
+							corev1.ResourceLimitsCPU: resource.MustParse("55"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	pool.CalculateClaimedResources()
+
+	// Even when claims exceed the hard limit, available must clamp at zero
+	// and Hard must stay intact (regression: subtracting in place corrupted
+	// both Hard and Available, producing negative values — see issue #1977).
+	actualAvailable := pool.Status.Allocation.Available[corev1.ResourceLimitsCPU]
+	assert.Equal(t, 0, (&actualAvailable).Cmp(resource.MustParse("0")))
+
+	actualHard := pool.Status.Allocation.Hard[corev1.ResourceLimitsCPU]
+	assert.Equal(t, 0, (&actualHard).Cmp(resource.MustParse("10")))
+
+	// With zero available, a new oversized claim must be rejected.
+	errs := pool.CanClaimFromPool(corev1.ResourceList{
+		corev1.ResourceLimitsCPU: resource.MustParse("55"),
+	})
+	assert.Len(t, errs, 1)
+}
+
 func TestCanClaimFromPool(t *testing.T) {
 	pool := &capsulev1beta2.ResourcePool{
 		Status: capsulev1beta2.ResourcePoolStatus{


### PR DESCRIPTION
## What
`CalculateAvailableResources` subtracted the claimed amount from the live `Hard` map entry (`qt.Sub(amount)` mutates the range value in place). When claims exceeded the hard limit this wrote a negative value into both `Status.Allocation.Available` and `Status.Allocation.Hard`, so the pool reported negative capacity and `Hard` itself got corrupted on every reconcile.

## Fix
- Compute available into a `DeepCopy()` of the hard quantity, leaving `Hard` intact.
- Clamp available at zero: a pool can never offer a negative amount of resources.

## Why this is the right place
With available clamped at zero, `CanClaimFromPool` correctly rejects a new oversized claim (`available.Cmp(req) < 0`), and `Hard` stays correct for downstream math. The webhook re-validates a patched `ResourcePoolClaim` against the pool, so an over-subscribed patch now surfaces a `PoolExhausted` condition instead of silently leaving a negative pool.

## Verification
Added `TestCalculateResources_OverSubscriptionDoesNotGoNegative` in `api/v1beta2/resourcepool_func_test.go`. `go test ./api/v1beta2/` passes, including the existing `TestCalculateResources`.

Fixes #1977