### PR TITLE
ci: add fossa project.team name

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,4 +1,4 @@
 version: 3
 
 project:
-  team: capsule
+  team: Capsule


### PR DESCRIPTION
This pull request makes a minor update to the `.fossa.yml` configuration file, correcting the capitalization of the `team` value.