### PR TITLE
fix: missing leader election namespace when running out-of-cluster

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -556,9 +556,10 @@ func main() {
 			Port:    webhookPort,
 			TLSOpts: webhookTLSOpts,
 		}),
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "42c733ea.clastix.capsule.io",
-		HealthProbeBindAddress: ":10080",
+		LeaderElection:          enableLeaderElection,
+		LeaderElectionID:        "42c733ea.clastix.capsule.io",
+		LeaderElectionNamespace: ns,
+		HealthProbeBindAddress:  ":10080",
 		NewClient: func(config *rest.Config, options client.Options) (client.Client, error) {
 			options.Cache.Unstructured = true
 


### PR DESCRIPTION
Noticed while debugging locally and checking leader election: when feeding a `kubeconfig` file, the Namespace can't be retrieved automatically.