### PR TITLE
fix(helm): fix manager.rbac.strict being no-op

### DIFF
--- a/charts/capsule/README.md
+++ b/charts/capsule/README.md
@@ -170,6 +170,7 @@ The following Values have changed key or Value:
 | manager.rbac.create | bool | `true` | Specifies whether RBAC resources should be created. |
 | manager.rbac.existingClusterRoles | list | `[]` | Specifies further cluster roles to be added to the Capsule manager service account. |
 | manager.rbac.existingRoles | list | `[]` | Specifies further cluster roles to be added to the Capsule manager service account. |
+| manager.rbac.minimal | bool | `false` | DEPRECATED: use strict instead. Former name of the strict option; takes effect when either flag is true. |
 | manager.rbac.role.extraResources | list | `[]` | Extra namespaced RBAC PolicyRules to add to a Role created by this chart and bound to the Capsule ServiceAccount. |
 | manager.rbac.strict | bool | `false` | Strongly restrict the RBAC assigned to Capsule Controller. When set to true you must aggregate further permissions by yourself. |
 | manager.readinessProbe | object | `{"httpGet":{"path":"/readyz","port":10080}}` | Configure the readiness probe using Deployment probe spec |

--- a/charts/capsule/templates/rbac.yaml
+++ b/charts/capsule/templates/rbac.yaml
@@ -106,7 +106,7 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "capsule.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
-    {{- if $.Values.manager.rbac.minimal }}
+    {{- if or $.Values.manager.rbac.strict $.Values.manager.rbac.minimal }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/capsule/values.schema.json
+++ b/charts/capsule/values.schema.json
@@ -693,6 +693,10 @@
                             "description": "Specifies further cluster roles to be added to the Capsule manager service account.",
                             "type": "array"
                         },
+                        "minimal": {
+                            "description": "DEPRECATED: use strict instead. Former name of the strict option; takes effect when either flag is true.",
+                            "type": "boolean"
+                        },
                         "role": {
                             "type": "object",
                             "properties": {

--- a/charts/capsule/values.yaml
+++ b/charts/capsule/values.yaml
@@ -156,6 +156,10 @@ manager:
     # When set to true you must aggregate further permissions by yourself.
     strict: false
 
+    # -- DEPRECATED: use strict instead.
+    # Former name of the strict option; takes effect when either flag is true.
+    minimal: false
+
     # -- Specifies further cluster roles to be added to the Capsule manager service account.
     existingClusterRoles: []
     # - cluster-admin


### PR DESCRIPTION
Fixes #2069 

This pull request introduces the new `manager.rbac.minimal` option to the Capsule Helm chart, marking it as deprecated in favor of the existing `manager.rbac.strict` option. The changes ensure backward compatibility by making both options effective when either is set to true, update documentation, and add schema support.

**RBAC Options and Backward Compatibility:**

* Added the `manager.rbac.minimal` boolean option to `values.yaml` and marked it as deprecated in favor of `manager.rbac.strict`, ensuring that either option enables strict RBAC behavior. [[1]](diffhunk://#diff-8facec49e536e52cd2044382bdb9bbd0227328f1977cfee6dc55f73886a67b7bR159-R162) [[2]](diffhunk://#diff-68a43cdb6d884fa53d9d62214e87777e98a1174a169a9b56909a6e41bb32e979R173)
* Updated the RBAC template logic in `rbac.yaml` so that either `strict` or `minimal` being true will apply the stricter RBAC configuration.

**Documentation and Schema Updates:**

* Updated the README and schema (`values.schema.json`) to describe the new `minimal` option, its deprecated status, and its behavior. [[1]](diffhunk://#diff-68a43cdb6d884fa53d9d62214e87777e98a1174a169a9b56909a6e41bb32e979R173) [[2]](diffhunk://#diff-5dcffeb9532f7c854625c86432de91692f7a9db0f1eb6bca88737ebb4a03b7d6R696-R699)