### PR TITLE
feat(chart): bind default owner clusterroles in strict rbac mode

### DIFF
--- a/charts/capsule/README.md
+++ b/charts/capsule/README.md
@@ -166,13 +166,14 @@ The following Values have changed key or Value:
 | manager.options.userNames | list | `[]` | DEPRECATED: use users properties. Names of the users considered as Capsule users. |
 | manager.options.users | list | `[{"kind":"Group","name":"projectcapsule.dev"}]` | Define entities which are considered part of the Capsule construct. Users not mentioned here will be ignored by Capsule |
 | manager.options.workers | int | `1` | Workers (MaxConcurrentReconciles) is the maximum number of concurrent Reconciles which can be run (ALPHA). |
+| manager.rbac.bindableClusterRoles | list | `["admin"]` | ClusterRoles the Capsule controller is allowed to bind (verb `bind`) when strict RBAC is enabled, in addition to the roles Capsule manages (manager.options.rbac provisioner, deleter, administrationClusterRoles and promotionClusterRoles), which are always bindable. Add any custom tenant-owner ClusterRoles here. |
 | manager.rbac.clusterRole.extraResources | list | `[]` | Extra cluster-scoped RBAC PolicyRules to add to a ClusterRole created by this chart and bound to the Capsule ServiceAccount. |
 | manager.rbac.create | bool | `true` | Specifies whether RBAC resources should be created. |
 | manager.rbac.existingClusterRoles | list | `[]` | Specifies further cluster roles to be added to the Capsule manager service account. |
 | manager.rbac.existingRoles | list | `[]` | Specifies further cluster roles to be added to the Capsule manager service account. |
 | manager.rbac.minimal | bool | `false` | DEPRECATED: use strict instead. Former name of the strict option; takes effect when either flag is true. |
 | manager.rbac.role.extraResources | list | `[]` | Extra namespaced RBAC PolicyRules to add to a Role created by this chart and bound to the Capsule ServiceAccount. |
-| manager.rbac.strict | bool | `false` | Strongly restrict the RBAC assigned to Capsule Controller. The default owner ClusterRoles (admin, provisioner and deleter) can be bound to tenant owners out of the box; permissions for anything beyond that (custom owner clusterRoles, TenantResource replication) must be aggregated by yourself via ClusterRoles labeled projectcapsule.dev/aggregate-to-controller: "true". |
+| manager.rbac.strict | bool | `false` | Strongly restrict the RBAC assigned to Capsule Controller. The default owner ClusterRoles (admin, provisioner and deleter) can be bound to tenant owners out of the box; add custom owner ClusterRoles via bindableClusterRoles. Permissions beyond binding (e.g. TenantResource replication) must be aggregated by yourself via ClusterRoles labeled projectcapsule.dev/aggregate-to-controller: "true". |
 | manager.readinessProbe | object | `{"httpGet":{"path":"/readyz","port":10080}}` | Configure the readiness probe using Deployment probe spec |
 | manager.resources | object | `{}` | Set the resource requests/limits for the Capsule manager container |
 | manager.securityContext | object | `{}` | Set the securityContext for the Capsule container |

--- a/charts/capsule/README.md
+++ b/charts/capsule/README.md
@@ -172,7 +172,7 @@ The following Values have changed key or Value:
 | manager.rbac.existingRoles | list | `[]` | Specifies further cluster roles to be added to the Capsule manager service account. |
 | manager.rbac.minimal | bool | `false` | DEPRECATED: use strict instead. Former name of the strict option; takes effect when either flag is true. |
 | manager.rbac.role.extraResources | list | `[]` | Extra namespaced RBAC PolicyRules to add to a Role created by this chart and bound to the Capsule ServiceAccount. |
-| manager.rbac.strict | bool | `false` | Strongly restrict the RBAC assigned to Capsule Controller. When set to true you must aggregate further permissions by yourself. |
+| manager.rbac.strict | bool | `false` | Strongly restrict the RBAC assigned to Capsule Controller. The default owner ClusterRoles (admin, provisioner and deleter) can be bound to tenant owners out of the box; permissions for anything beyond that (custom owner clusterRoles, TenantResource replication) must be aggregated by yourself via ClusterRoles labeled projectcapsule.dev/aggregate-to-controller: "true". |
 | manager.readinessProbe | object | `{"httpGet":{"path":"/readyz","port":10080}}` | Configure the readiness probe using Deployment probe spec |
 | manager.resources | object | `{}` | Set the resource requests/limits for the Capsule manager container |
 | manager.securityContext | object | `{}` | Set the securityContext for the Capsule container |

--- a/charts/capsule/ci/strict-values.yaml
+++ b/charts/capsule/ci/strict-values.yaml
@@ -3,3 +3,6 @@ manager:
   rbac:
     create: true
     strict: true
+    bindableClusterRoles:
+      - admin
+      - edit

--- a/charts/capsule/ci/strict-values.yaml
+++ b/charts/capsule/ci/strict-values.yaml
@@ -1,0 +1,5 @@
+fullnameOverride: capsule
+manager:
+  rbac:
+    create: true
+    strict: true

--- a/charts/capsule/templates/rbac.yaml
+++ b/charts/capsule/templates/rbac.yaml
@@ -273,6 +273,7 @@ rules:
   - "get"
   - "list"
   - "watch"
+  - "create"
   - "patch"
   - "update"
   - "delete"
@@ -434,6 +435,14 @@ rules:
   - patch
   - delete
 - apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles"]
+  resourceNames:
+    - admin
+    - {{ $.Values.manager.options.rbac.provisioner}}
+    - {{ $.Values.manager.options.rbac.deleter}}
+  verbs:
+  - bind
+- apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["clusterrolebindings"]
   verbs:
   - "list"
@@ -462,6 +471,9 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get", "list", "watch", "create", "update", "patch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/capsule/templates/rbac.yaml
+++ b/charts/capsule/templates/rbac.yaml
@@ -434,12 +434,13 @@ rules:
   - update
   - patch
   - delete
+{{- $bindable := concat $.Values.manager.rbac.bindableClusterRoles (list $.Values.manager.options.rbac.provisioner $.Values.manager.options.rbac.deleter) $.Values.manager.options.rbac.administrationClusterRoles $.Values.manager.options.rbac.promotionClusterRoles | uniq | sortAlpha }}
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["clusterroles"]
   resourceNames:
-    - admin
-    - {{ $.Values.manager.options.rbac.provisioner}}
-    - {{ $.Values.manager.options.rbac.deleter}}
+    {{- range $bindable }}
+    - {{ . | quote }}
+    {{- end }}
   verbs:
   - bind
 - apiGroups: ["rbac.authorization.k8s.io"]

--- a/charts/capsule/values.schema.json
+++ b/charts/capsule/values.schema.json
@@ -672,6 +672,13 @@
                 "rbac": {
                     "type": "object",
                     "properties": {
+                        "bindableClusterRoles": {
+                            "description": "ClusterRoles the Capsule controller is allowed to bind (verb `bind`) when strict RBAC is enabled, in addition to the roles Capsule manages (manager.options.rbac provisioner, deleter, administrationClusterRoles and promotionClusterRoles), which are always bindable. Add any custom tenant-owner ClusterRoles here.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
                         "clusterRole": {
                             "type": "object",
                             "properties": {
@@ -707,7 +714,7 @@
                             }
                         },
                         "strict": {
-                            "description": "Strongly restrict the RBAC assigned to Capsule Controller. The default owner ClusterRoles (admin, provisioner and deleter) can be bound to tenant owners out of the box; permissions for anything beyond that (custom owner clusterRoles, TenantResource replication) must be aggregated by yourself via ClusterRoles labeled projectcapsule.dev/aggregate-to-controller: \"true\".",
+                            "description": "Strongly restrict the RBAC assigned to Capsule Controller. The default owner ClusterRoles (admin, provisioner and deleter) can be bound to tenant owners out of the box; add custom owner ClusterRoles via bindableClusterRoles. Permissions beyond binding (e.g. TenantResource replication) must be aggregated by yourself via ClusterRoles labeled projectcapsule.dev/aggregate-to-controller: \"true\".",
                             "type": "boolean"
                         }
                     }

--- a/charts/capsule/values.schema.json
+++ b/charts/capsule/values.schema.json
@@ -707,7 +707,7 @@
                             }
                         },
                         "strict": {
-                            "description": "Strongly restrict the RBAC assigned to Capsule Controller. When set to true you must aggregate further permissions by yourself.",
+                            "description": "Strongly restrict the RBAC assigned to Capsule Controller. The default owner ClusterRoles (admin, provisioner and deleter) can be bound to tenant owners out of the box; permissions for anything beyond that (custom owner clusterRoles, TenantResource replication) must be aggregated by yourself via ClusterRoles labeled projectcapsule.dev/aggregate-to-controller: \"true\".",
                             "type": "boolean"
                         }
                     }

--- a/charts/capsule/values.yaml
+++ b/charts/capsule/values.yaml
@@ -153,7 +153,10 @@ manager:
     create: true
 
     # -- Strongly restrict the RBAC assigned to Capsule Controller.
-    # When set to true you must aggregate further permissions by yourself.
+    # The default owner ClusterRoles (admin, provisioner and deleter) can be bound
+    # to tenant owners out of the box; permissions for anything beyond that (custom
+    # owner clusterRoles, TenantResource replication) must be aggregated by yourself
+    # via ClusterRoles labeled projectcapsule.dev/aggregate-to-controller: "true".
     strict: false
 
     # -- DEPRECATED: use strict instead.

--- a/charts/capsule/values.yaml
+++ b/charts/capsule/values.yaml
@@ -154,14 +154,23 @@ manager:
 
     # -- Strongly restrict the RBAC assigned to Capsule Controller.
     # The default owner ClusterRoles (admin, provisioner and deleter) can be bound
-    # to tenant owners out of the box; permissions for anything beyond that (custom
-    # owner clusterRoles, TenantResource replication) must be aggregated by yourself
-    # via ClusterRoles labeled projectcapsule.dev/aggregate-to-controller: "true".
+    # to tenant owners out of the box; add custom owner ClusterRoles via
+    # bindableClusterRoles. Permissions beyond binding (e.g. TenantResource
+    # replication) must be aggregated by yourself via ClusterRoles labeled
+    # projectcapsule.dev/aggregate-to-controller: "true".
     strict: false
 
     # -- DEPRECATED: use strict instead.
     # Former name of the strict option; takes effect when either flag is true.
     minimal: false
+
+    # -- ClusterRoles the Capsule controller is allowed to bind (verb `bind`) when
+    # strict RBAC is enabled, in addition to the roles Capsule manages
+    # (manager.options.rbac provisioner, deleter, administrationClusterRoles and
+    # promotionClusterRoles), which are always bindable. Add any custom
+    # tenant-owner ClusterRoles here.
+    bindableClusterRoles:
+      - admin
 
     # -- Specifies further cluster roles to be added to the Capsule manager service account.
     existingClusterRoles: []


### PR DESCRIPTION
resolves second part of #2069 
feat(chart): bind default owner ClusterRoles in strict RBAC mode